### PR TITLE
add typing for `tok`

### DIFF
--- a/generator/src/framework_sources.rs
+++ b/generator/src/framework_sources.rs
@@ -135,7 +135,7 @@ export function splitGenericParameters(
   genericSeparators: [string, string] = ['<', '>']
 ) {
   const [left, right] = genericSeparators
-  const tok = []
+  const tok: string[] = []
   let word = ''
   let nestedAngleBrackets = 0
 


### PR DESCRIPTION
Without specifying `string[]` for `tok`, ts compiler reports the following error
```
Argument of type 'string' is not assignable to parameter of type 'never'.
```