### PR TITLE
fix toField

### DIFF
--- a/generator/src/framework_sources.rs
+++ b/generator/src/framework_sources.rs
@@ -679,16 +679,6 @@ export type ToField<T extends TypeArgument> = T extends 'bool'
   ? bigint
   : T extends 'address'
   ? string
-  : T extends { $typeName: '0x1::string::String' }
-  ? string
-  : T extends { $typeName: '0x1::ascii::String' }
-  ? string
-  : T extends { $typeName: '0x2::object::UID' }
-  ? string
-  : T extends { $typeName: '0x2::object::ID' }
-  ? string
-  : T extends { $typeName: '0x2::url::Url' }
-  ? string
   : T extends {
       $typeName: '0x1::option::Option'
       __inner: infer U extends TypeArgument


### PR DESCRIPTION
`toField` type function converts move `String`, `UID`, `ID`, `Url` to js string type, which results a run time mismatch, at runtime, these type returns `String` type, `UID`, `ID`, `Url` correspondingly, therefore `toField` shouldn't transform them.