### PR TITLE
feat(codegen): make $typeName follow setActiveEnv via getters

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -235,16 +235,16 @@ To build a scoped config, use `cloneEnv()` to derive one from a registered env (
 
 ```ts
 import { cloneEnv, getEnv } from './gen/_envs'
-import { createRebalanceReceipt } from './gen/kai-leverage/position-core-clmm/functions'
+import { transfer } from './gen/my-app/escrow/functions'
 
 // Point a single call at a historical publishedAt, leaving every other package unchanged.
 const historical = cloneEnv(getEnv('mainnet'), {
   packages: {
-    'kai-leverage': { publishedAt: '0xHISTORICAL_ADDRESS' },
+    'my-app': { publishedAt: '0xHISTORICAL_ADDRESS' },
   },
 })
 
-createRebalanceReceipt(tx, typeArgs, args, { env: historical })
+transfer(tx, typeArgs, args, { env: historical })
 ```
 
 `cloneEnv` shallow-merges per-package: fields you provide replace the base fields, `typeOrigins` are merged (not replaced), and every other package in `base` is preserved. Overriding a package name that doesn't exist in `base` throws.
@@ -256,7 +256,7 @@ Typical uses:
 - Fan-out processing where each task operates against a different `publishedAt` concurrently.
 - Decoding type origins for a cross-env payload (e.g. `getTypeOrigin('pkg', 'mod::T', otherEnv)`).
 
-Note: per-call `env` currently covers move calls (function bindings) and the env resolvers. Struct classes (`Foo.reified()`, `Foo.fetch()`, `Foo.fromSuiParsedData()`) still read `$typeName` from the active env — cross-env decoding of struct instances still uses `setActiveEnv` today.
+Note: per-call `env` covers move calls (function bindings) and the env resolvers, not the struct-class static methods. `Foo.reified()`, `Foo.fetch()`, `Foo.fromSuiParsedData()` etc. don't accept an `env` argument — they resolve `$typeName` against the active env. Switching that active env with `setActiveEnv()` is reflected on every subsequent read (including stored `reified()` handles and `phantom()` wrappers — see [ADR-005](docs/adr/005-dynamic-typename-via-getters.md)), so cross-env decoding works, but you can't pin a single decode call to a specific env without flipping the active one. Multi-env-instances-in-one-process is the planned next step.
 
 ### Querying Active Environment
 
@@ -379,7 +379,7 @@ Move field types are mapped to TS types as follows:
 | `0x1::option::Option<T>`    | `T \| null`   |
 | `vector<T>`                 | `T[]`        |
 
-The struct class holds the above fields as well as the `$typeName` and `$numTypeParams` static fields and the `$typeArgs` field in case the struct has type parameters. The `$typeName` field holds the full name of the type with the address but without type parameters (e.g., `0x2::balance::Balance` and not `0x2::balance::Balance<T>`).
+The struct class holds the above fields as well as the `$typeName` and `$numTypeParams` static fields and the `$typeArgs` field in case the struct has type parameters. `$typeName` holds the full name of the type with the address but without type parameters (e.g., `0x2::balance::Balance`, not `0x2::balance::Balance<T>`). For packages whose address depends on the environment (everything except system packages at `0x1`/`0x2`), `$typeName` is emitted as a static getter that resolves the address against the active env on every read — see [ADR-005](docs/adr/005-dynamic-typename-via-getters.md).
 
 The struct class can be instantiated in multiple ways:
 - using the constructor by passing in the fields manually

--- a/docs/adr/005-dynamic-typename-via-getters.md
+++ b/docs/adr/005-dynamic-typename-via-getters.md
@@ -1,0 +1,317 @@
+# ADR 005: Dynamic `$typeName` via Static Getters
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-003 introduced runtime environment switching: `setActiveEnv()` flips a
+module-level slot that resolvers like `getTypeOrigin()` and `getPublishedAt()`
+read on each call. Function-binding `target` strings interpolate
+`getPublishedAt(...)` at PTB-build time, so they follow env switches correctly.
+
+Generated struct and enum classes also carry their fully-qualified Move type
+name. Originally this was emitted as a `static readonly` field whose value was
+computed at class-load time:
+
+```ts
+export class Section implements StructClass {
+  static readonly $typeName: `${string}::piecewise::Section` = `${
+    getTypeOrigin('my-app', 'piecewise::Section')
+  }::piecewise::Section` as const
+  // ...
+}
+```
+
+The right-hand side of a `static readonly` initializer runs once, when the
+class is first loaded — and the auto-init in `_envs/index.ts` calls
+`setActiveEnv('<default>')` before any user code runs. So every Dynamic-package
+`$typeName` was frozen against whichever env was the default at import time
+(typically mainnet), regardless of any later `setActiveEnv()` call.
+
+This caused real bugs:
+
+```ts
+import { setActiveEnv } from './gen/_envs'
+import { create as piecewiseCreate } from './gen/my-app/piecewise/functions'
+
+setActiveEnv('local')
+
+const tx = new Transaction()
+piecewiseCreate(tx, { /* ... */ sections: [...] })
+//  → tx.moveCall.target   = '0xLOCAL::piecewise::create' (correct — runtime)
+//  → vector<Section> type = '0xMAINNET::piecewise::Section' (wrong — frozen)
+//  → dry-run fails: "Dependent package not found on-chain"
+```
+
+The leak compounds through reified handles. Code that stores a reified handle
+across an env switch — common in SDK builders that cache `this.r = Foo.r(...)`
+in constructors or in module-level constants — also reads stale identity
+strings, because the reified return object's `typeName` / `fullTypeName` /
+`typeArgs` fields were plain values captured at the moment `reified()` was
+called. `phantom(reified)` had the same issue: it stored `reified.fullTypeName`
+into `phantomType` as a snapshot, which `extractType()` then read.
+
+`std` and `sui` types weren't affected — their addresses are constant on every
+chain (`0x1`, `0x2`), so the frozen value happens to always be correct.
+
+## Decision
+
+Make `$typeName` read the active env on every access for non-system packages,
+and propagate the same lazy-read pattern through every site that captures it.
+Four changes, all backward compatible at every read site:
+
+### 1. Struct/enum `$typeName` becomes a getter for Dynamic packages
+
+```ts
+// Before
+static readonly $typeName: `${string}::piecewise::Section` = `${
+  getTypeOrigin('my-app', 'piecewise::Section')
+}::piecewise::Section` as const
+
+// After
+static get $typeName(): `${string}::piecewise::Section` {
+  return `${getTypeOrigin('my-app', 'piecewise::Section')}::piecewise::Section` as const
+}
+```
+
+System packages (std at `0x1`, sui at `0x2`) keep `static readonly`. Their
+addresses are constant across chains, and the literal-typed field preserves
+precise template-literal type narrowing (e.g.
+`` `0x2::balance::Balance` `` rather than `` `${string}::balance::Balance` ``).
+
+### 2. Enum variant `$typeName` delegates via a getter
+
+```ts
+// Before
+static readonly $typeName: typeof Action.$typeName = Action.$typeName
+
+// After
+static get $typeName(): typeof Action.$typeName { return Action.$typeName }
+```
+
+Variant classes used to read the enum's `$typeName` at class-load time. Even
+after fix 1 made the enum dynamic, variants would re-freeze on first variant
+class load. A delegating getter forwards each read through to the (now dynamic)
+enum getter.
+
+### 3. `reified()` identity fields become object-literal getters
+
+```ts
+static reified(): SectionReified {
+  return {
+    get typeName() { return Section.$typeName },
+    get fullTypeName() {
+      return composeSuiType(Section.$typeName, ...[]) as `${string}::piecewise::Section`
+    },
+    typeArgs: [] as [],
+    // ...
+  }
+}
+```
+
+For structs with type parameters, `typeArgs` is also a getter (its
+`extractType(...)` calls reach through reified handles whose own
+`fullTypeName` is now dynamic):
+
+```ts
+get typeArgs() {
+  return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+}
+```
+
+This is what makes stored reified handles (e.g. `this.r =
+SupplyPool_.r(args.T.r, args.ST.r)`, or module-level
+`Position_.r(USDC.p, SUI.p)` constants) follow env switches: subsequent reads
+of `stored.typeName` / `stored.fullTypeName` / `stored.typeArgs` re-resolve
+each time.
+
+### 4. `phantom(reifiedHandle).phantomType` is a getter
+
+```ts
+// Before
+return { phantomType: type.fullTypeName, kind: 'PhantomReified' }
+
+// After
+return {
+  get phantomType() { return type.fullTypeName },
+  kind: 'PhantomReified',
+}
+```
+
+The recursion is then end-to-end: `PhantomReified.phantomType` → reified
+handle's `fullTypeName` getter → struct's `$typeName` getter →
+`getTypeOrigin(...)` → active env. `phantom(stringLiteral)` stays a plain
+field (the input was already a finalized string; nothing to keep live).
+
+The `PhantomReified.phantomType` interface field is also marked `readonly` —
+it should have been from the start, and the getter implementation requires it
+to be readable but not assignable.
+
+## Rationale
+
+### Why getter, not method
+
+A method (`Foo.typeName(env?)`) would let callers pass an explicit env per
+call, which would be cleaner for the eventual per-instance facade design
+(see *Future* below). It also has a downside: every existing read site has
+to migrate from
+property access (`Foo.$typeName`, `${Foo.$typeName}`) to method invocation
+(`Foo.typeName()`, `${Foo.typeName()}`). That's invasive both in generated
+code (BCS template names, JSON validation, type guards) and in consumer code.
+
+A getter keeps property-access syntax everywhere unchanged. Every read site —
+generated and user code — continues to work without modification, and just
+starts reflecting the active env on each access. The trade-off (no explicit
+per-call env parameter on the static surface) is intentional and recovered
+later when the design moves to a per-instance facade.
+
+### Why preserve `static readonly` for system packages
+
+The motivating bug only exists for packages whose address depends on the env.
+System packages don't change across chains, so the freeze is benign. Keeping
+`static readonly ... as const` for them:
+
+- Preserves the precise literal type (`` `0x2::balance::Balance` `` rather
+  than `` `${string}::balance::Balance` ``) for any consumer doing
+  type-narrowed string operations.
+- Avoids an unnecessary getter invocation on every read.
+
+The conditional gate is the only place in the emission templates where
+`PackageInfo::System` vs `PackageInfo::Dynamic` is observed. A
+`make_system_struct_ir()` / `make_system_enum_ir()` snapshot fixture pins this
+so a future refactor can't silently turn `static readonly` into a getter for
+system types.
+
+### Why also fix the reified return object and `phantom()`
+
+The reported bug surfaced through `vector<Section>` type-arg strings, which
+read `Section.$typeName` at PTB-build time. Fix #1 alone is enough for that
+specific failure mode.
+
+But the broader pattern in SDKs that wrap the generated output is to store
+reified handles as long-lived state:
+
+```ts
+// In an SDK wrapping the generated bindings
+this.r = SupplyPool_.r(args.T.r, args.ST.r)
+// ...later, on every PTB method:
+addLendFacil(tx, this.r.typeArgs, { ... })
+```
+
+The handle is captured under one env, the methods called under another. Fix
+#3 (object-literal getters in reified) and Fix #4 (lazy `phantomType` in
+`phantom()`) make stored handles read live. Without them, the reported bug
+would persist via the reified-handle path even though the direct `$typeName`
+read is fixed.
+
+### Why the `phantom(string)` branch stays a snapshot
+
+`phantom(reified)` reads its argument's `fullTypeName` which is now a getter.
+`phantom(stringLiteral)` receives an already-finalized string — there's
+nothing to keep live. The asymmetry is intentional and pinned by a runtime
+test.
+
+### Snapshot semantics for *instances*
+
+`new Foo([], fields)` continues to read `Foo.$typeName` once at construction
+and freeze the result onto `this.$typeName`. This is correct: an instance
+carries the identity it was decoded under, so `toJSON()` round-trips back to
+the same `$typeName`. Decoding in env A and re-serializing in env B should
+not silently relabel the instance.
+
+The split is: **static surface and reified handles are dynamic; constructed
+instances are snapshots.** Both are read through `Name.$typeName` (the
+getter), so the read site is uniform; only the *capture site* differs.
+
+## Consequences
+
+### Positive
+
+- **`setActiveEnv()` is honest end-to-end.** Every downstream `$typeName`
+  read — vector/option PTB args, BCS template names, JSON discriminator
+  checks, `composeSuiType` inputs, `PhantomReified` chains — reflects the
+  current env.
+- **No consumer code changes.** `Foo.$typeName`, `Foo.r(...).typeArgs`,
+  `phantom(Foo.reified()).phantomType` all keep working unchanged. No call
+  sites in generated code or user code need to migrate.
+- **Stored reified handles work.** The pattern of caching
+  `this.r = Foo.r(...)` in a higher-level SDK wrapper and reading
+  `this.r.typeArgs` later survives env switches.
+- **System types keep their literal narrowing.** Consumers that type-narrow
+  on `Section.$typeName` still see the exact literal for std/sui types.
+
+### Negative
+
+- **Each access pays a small lookup.** A getter walks
+  `getActiveEnv().packages[pkg].typeOrigins[path]` plus a template-literal
+  build. Negligible at PTB-build time; the only path that's hot is decoding
+  in tight loops, and BCS itself is already env-independent so it skips the
+  getter.
+- **Reference equality of array-typed fields changes.** `r.typeArgs ===
+  r.typeArgs` was `true` (same array), is now `false` (new array per read).
+  No realistic consumer relies on this; iteration/indexing/destructuring
+  are unaffected.
+- **Two parallel surfaces if a method form is added later.** When env
+  becomes an explicit parameter (see *Future*), the getter form and the
+  method form will coexist. Acceptable as a bridge; the method form will
+  become the recommended API.
+- **Still single-env-at-a-time.** The fix makes the global slot work
+  correctly under switching, but two callers needing different envs
+  concurrently still can't both be right. This is what the facade rework
+  addresses.
+
+## Future
+
+The bridge approach assumes there is one current env at a time. The cleaner
+long-term design eliminates the global env entirely:
+
+- Generated function wrappers gain an optional `env?: EnvConfig` parameter
+  threaded through every call (already shipped — see DOC.md "Per-Call
+  Environment Override").
+- Static class members (`$typeName`, decoder methods, `reified()`) gain an
+  optional `env?` parameter alongside the getter form, so consumers can
+  read against a specific env without flipping the global slot.
+- A `new Sdk({ env })`-style facade owns env on its instance and routes
+  `this.env` into every call. Multiple facade instances coexist with no
+  global mutation.
+
+Under that design, the getters from this ADR become the global-env fallback
+path — still correct for direct-import consumers, but inert when env is
+passed explicitly. Nothing here paints the redesign into a corner.
+
+## Implementation
+
+### Generator changes
+
+| File | Change |
+|------|--------|
+| `generator/src/ts_gen/structs.rs` | `emit_static_type_name_decl()` helper emits `static readonly` for System or `static get` for Dynamic. `reified()` `typeName` / `fullTypeName` / `typeArgs` are object-literal getters. |
+| `generator/src/ts_gen/enums.rs` | Same helper for both no-typeparam and typeparam enum factories. Variant classes' `static $typeName` is a delegating getter. Reified identity fields are object-literal getters. |
+| `generator/framework/reified.ts` | `phantom(reifiedHandle)` returns a getter for `phantomType`. `PhantomReified.phantomType` marked `readonly`. |
+
+### Test coverage
+
+- **Rust snapshot tests** (`generator/tests/snapshot_tests.rs`): the existing
+  Dynamic-package fixtures get the new emission shape. Two new System-package
+  fixtures (`make_system_struct_ir`, `make_system_enum_ir`) pin the
+  `static readonly` path with invariant assertions.
+- **TypeScript runtime tests** (`ts/tests/type-name-env-switching.test.ts`):
+  end-to-end coverage of `setActiveEnv()` behavior — Dynamic `$typeName`
+  follows the active env, System stays constant, stored `reified()` handles
+  reflect env changes, nested reified args propagate through `extractType`,
+  `phantom(reified).phantomType` re-reads on each access, and
+  `phantom(stringLiteral)` stays a snapshot.
+
+## References
+
+- `generator/src/ts_gen/structs.rs::emit_static_type_name_decl()` and the
+  reified emission templates.
+- `generator/src/ts_gen/enums.rs::emit_static_type_name_decl()` and the
+  variant emission blocks.
+- `generator/framework/reified.ts::phantom()`.
+- `ts/tests/type-name-env-switching.test.ts` — runtime verification.
+- ADR-003 — Multi-environment generation (origin of `setActiveEnv()`).
+- DOC.md "Per-Call Environment Override" — current scope of per-call `env`
+  and the path toward removing the global slot.

--- a/generator/framework/env.ts
+++ b/generator/framework/env.ts
@@ -71,9 +71,9 @@ export function getEnv(name: string): EnvConfig {
  *
  * @example
  *   const historical = cloneEnv(getEnv('mainnet'), {
- *     packages: { 'kai-leverage': { publishedAt: '0x...' } },
+ *     packages: { 'my-app': { publishedAt: '0x...' } },
  *   })
- *   createRebalanceReceipt(tx, typeArgs, args, { env: historical })
+ *   transfer(tx, typeArgs, args, { env: historical })
  */
 export function cloneEnv(
   base: EnvConfig,

--- a/generator/framework/reified.ts
+++ b/generator/framework/reified.ts
@@ -120,7 +120,7 @@ export type ToPhantomTypeArgument<T extends PhantomReified<PhantomTypeArgument>>
 export type PhantomTypeArgument = string
 
 export interface PhantomReified<P> {
-  phantomType: P
+  readonly phantomType: P
   kind: 'PhantomReified'
 }
 
@@ -135,8 +135,15 @@ export function phantom(type: string | Reified<TypeArgument, any>): PhantomReifi
       kind: 'PhantomReified',
     }
   } else {
+    // Reified handle case: read `fullTypeName` lazily so phantom handles created
+    // before `setActiveEnv(...)` still reflect the current env on each access.
+    // Without this getter, `phantomType` would freeze the typeName at phantom-call time
+    // and leak the wrong address into vector/option type-arg strings produced via
+    // `extractType(...)`.
     return {
-      phantomType: type.fullTypeName,
+      get phantomType() {
+        return type.fullTypeName
+      },
       kind: 'PhantomReified',
     }
   }

--- a/generator/src/ts_gen/enums.rs
+++ b/generator/src/ts_gen/enums.rs
@@ -130,6 +130,29 @@ impl EnumIR {
         matches!(&self.package_info, PackageInfo::Dynamic { .. })
     }
 
+    /// Emit the `static $typeName` declaration.
+    ///
+    /// System packages (std at `0x1`, sui at `0x2`) emit a `static readonly` so the
+    /// literal type is preserved. Dynamic packages emit a `static get` whose body
+    /// re-resolves on each access, keeping `Name.$typeName` env-current after
+    /// `setActiveEnv(...)` calls.
+    fn emit_static_type_name_decl(
+        &self,
+        full_type_template: &str,
+        full_type_as_type: &str,
+    ) -> String {
+        match &self.package_info {
+            PackageInfo::System { .. } => format!(
+                "static readonly $typeName: {} = `{}` as const",
+                full_type_as_type, full_type_template
+            ),
+            PackageInfo::Dynamic { .. } => format!(
+                "static get $typeName(): {} {{\n    return `{}` as const\n  }}",
+                full_type_as_type, full_type_template
+            ),
+        }
+    }
+
     fn emit_type_guard(&self) -> String {
         let full_type_template = self.full_type_name_template();
 
@@ -303,6 +326,8 @@ impl EnumIR {
             let extract_types = self.emit_extract_types();
             let full_type_as_type = self.emit_full_type_as_type();
             let full_type_as_type_for_static = self.emit_full_type_as_type_for_static();
+            let type_name_decl =
+                self.emit_static_type_name_decl(&full_type_template, &full_type_as_type_for_static);
             let type_args_as_type = self.emit_type_args_as_type();
             let bcs_section = self.emit_bcs_section();
             let reified_bcs_init = self.emit_reified_bcs_init();
@@ -320,7 +345,7 @@ impl EnumIR {
 
             formatdoc! {r#"
                 export class {name} {{
-                  static readonly $typeName: {full_type_as_type_for_static} = `{full_type_template}` as const
+                  {type_name_decl}
                   static readonly $numTypeParams = {num_type_params}
                   static readonly $isPhantom = {is_phantom_array} as const
 
@@ -329,12 +354,14 @@ impl EnumIR {
                   ): {name}Reified{to_type_args} {{
                     const reifiedBcs = {reified_bcs_init}
                     return {{
-                      typeName: {name}.$typeName,
-                      fullTypeName: composeSuiType(
-                        {name}.$typeName,
-                        ...[{extract_types}]
-                      ) as {full_type_as_type},
-                      typeArgs: [{extract_types}] as {type_args_as_type},
+                      get typeName() {{ return {name}.$typeName }},
+                      get fullTypeName() {{
+                        return composeSuiType(
+                          {name}.$typeName,
+                          ...[{extract_types}]
+                        ) as {full_type_as_type}
+                      }},
+                      get typeArgs() {{ return [{extract_types}] as {type_args_as_type} }},
                       isPhantom: {name}.$isPhantom,
                       reifiedTypeArgs: [{reified_arg_names}],
                       fromFields: (fields: Record<string, any>) => {name}.fromFields([{reified_arg_names}], fields),
@@ -446,7 +473,7 @@ impl EnumIR {
                 }}"#,
                 name = name,
                 name_lower = name.to_lowercase(),
-                full_type_template = full_type_template,
+                type_name_decl = type_name_decl,
                 num_type_params = num_type_params,
                 is_phantom_array = is_phantom_array,
                 reified_type_params = reified_type_params,
@@ -475,6 +502,8 @@ impl EnumIR {
         let name = &self.name;
         let full_type_template = self.full_type_name_template();
         let full_type_as_type_for_static = self.emit_full_type_as_type_for_static();
+        let type_name_decl =
+            self.emit_static_type_name_decl(&full_type_template, &full_type_as_type_for_static);
         let bcs_section = self.emit_bcs_section();
         let new_switch_cases = self.emit_new_switch_cases_no_type_params();
         let from_fields_switch = self.emit_from_fields_switch();
@@ -483,15 +512,15 @@ impl EnumIR {
 
         formatdoc! {r#"
             export class {name} {{
-              static readonly $typeName: {full_type_as_type_for_static} = `{full_type_template}` as const
+              {type_name_decl}
               static readonly $numTypeParams = 0
               static readonly $isPhantom = [] as const
 
               static reified(): {name}Reified {{
                 const reifiedBcs = {name}.bcs
                 return {{
-                  typeName: {name}.$typeName,
-                  fullTypeName: composeSuiType({name}.$typeName) as `{full_type_template}`,
+                  get typeName() {{ return {name}.$typeName }},
+                  get fullTypeName() {{ return composeSuiType({name}.$typeName) as `{full_type_template}` }},
                   typeArgs: [] as [],
                   isPhantom: {name}.$isPhantom,
                   reifiedTypeArgs: [],
@@ -578,6 +607,7 @@ impl EnumIR {
             }}"#,
             name = name,
             name_lower = name.to_lowercase(),
+            type_name_decl = type_name_decl,
             full_type_template = full_type_template,
             bcs_section = bcs_section,
             new_switch_cases = new_switch_cases,
@@ -684,7 +714,7 @@ impl EnumIR {
                 {{
                   __EnumVariantClass = true as const
 
-                  static readonly $typeName: typeof {enum_name}.$typeName = {enum_name}.$typeName
+                  static get $typeName(): typeof {enum_name}.$typeName {{ return {enum_name}.$typeName }}
                   static readonly $numTypeParams: typeof {enum_name}.$numTypeParams = {enum_name}.$numTypeParams
                   static readonly $isPhantom: typeof {enum_name}.$isPhantom = {enum_name}.$isPhantom
                   static readonly $variantName = '{variant_name}' as const
@@ -747,7 +777,7 @@ impl EnumIR {
                 {{
                   __EnumVariantClass = true as const
 
-                  static readonly $typeName: typeof {enum_name}.$typeName = {enum_name}.$typeName
+                  static get $typeName(): typeof {enum_name}.$typeName {{ return {enum_name}.$typeName }}
                   static readonly $numTypeParams: typeof {enum_name}.$numTypeParams = {enum_name}.$numTypeParams
                   static readonly $isPhantom: typeof {enum_name}.$isPhantom = {enum_name}.$isPhantom
                   static readonly $variantName = '{variant_name}' as const

--- a/generator/src/ts_gen/structs.rs
+++ b/generator/src/ts_gen/structs.rs
@@ -397,6 +397,33 @@ impl StructIR {
         matches!(&self.package_info, PackageInfo::Dynamic { .. })
     }
 
+    /// Emit the `static $typeName` declaration.
+    ///
+    /// For System packages the address is constant across all chains, so we emit a
+    /// `static readonly` with `as const` to preserve the precise literal type
+    /// (e.g. `\`0x2::balance::Balance\``).
+    ///
+    /// For Dynamic packages the address depends on the active environment, so we
+    /// emit a `static get` whose body re-resolves on each access. This keeps
+    /// `Name.$typeName` correct after `setActiveEnv(...)` calls and matches the
+    /// runtime behavior the function-binding `target` already has.
+    fn emit_static_type_name_decl(
+        &self,
+        full_type_template: &str,
+        full_type_as_type: &str,
+    ) -> String {
+        match &self.package_info {
+            PackageInfo::System { .. } => format!(
+                "static readonly $typeName: {} = `{}` as const",
+                full_type_as_type, full_type_template
+            ),
+            PackageInfo::Dynamic { .. } => format!(
+                "static get $typeName(): {} {{\n    return `{}` as const\n  }}",
+                full_type_as_type, full_type_template
+            ),
+        }
+    }
+
     fn emit_fields_interface(&self) -> String {
         let type_params_decl = self.emit_type_params_decl();
 
@@ -486,6 +513,7 @@ impl StructIR {
     fn emit_class_no_type_params(&self) -> String {
         let full_type_template = self.full_type_name_template();
         let full_type_as_type = self.full_type_name_as_type();
+        let type_name_decl = self.emit_static_type_name_decl(&full_type_template, &full_type_as_type);
 
         let field_decls: Vec<String> = self
             .fields
@@ -566,7 +594,7 @@ impl StructIR {
             export class {name} implements StructClass {{
               __StructClass = true as const
 
-              static readonly $typeName: {full_type_as_type} = `{full_type_template}` as const
+              {type_name_decl}
               static readonly $numTypeParams = 0
               static readonly $isPhantom = [] as const
 
@@ -590,11 +618,13 @@ impl StructIR {
               static reified(): {name}Reified {{
                 const reifiedBcs = {name}.bcs
                 return {{
-                  typeName: {name}.$typeName,
-                  fullTypeName: composeSuiType(
-                    {name}.$typeName,
-                    ...[]
-                  ) as {full_type_as_type},
+                  get typeName() {{ return {name}.$typeName }},
+                  get fullTypeName() {{
+                    return composeSuiType(
+                      {name}.$typeName,
+                      ...[]
+                    ) as {full_type_as_type}
+                  }},
                   typeArgs: [] as [],
                   isPhantom: {name}.$isPhantom,
                   reifiedTypeArgs: [],
@@ -721,7 +751,7 @@ impl StructIR {
               }}
             }}"#,
             name = self.name,
-            full_type_template = full_type_template,
+            type_name_decl = type_name_decl,
             full_type_as_type = full_type_as_type,
             field_decls = field_decls.join("\n"),
             field_assignments = field_assignments.join("\n"),
@@ -743,6 +773,8 @@ impl StructIR {
     fn emit_class_with_type_params(&self) -> String {
         let full_type_template = self.full_type_name_template();
         let full_type_as_type_no_generics = self.full_type_name_as_type();
+        let type_name_decl =
+            self.emit_static_type_name_decl(&full_type_template, &full_type_as_type_no_generics);
 
         // Build various type-param-related strings
         let type_param_extends = self.emit_type_param_extends();
@@ -959,7 +991,7 @@ impl StructIR {
             export class {name}{type_param_extends} implements StructClass {{
               __StructClass = true as const
 
-              static readonly $typeName: {full_type_as_type_no_generics} = `{full_type_template}` as const
+              {type_name_decl}
               static readonly $numTypeParams = {num_type_params}
               static readonly $isPhantom = {is_phantom_array} as const
             {inner_fields_section}
@@ -985,12 +1017,14 @@ impl StructIR {
               ): {name}Reified{to_phantom_type_args} {{
                 const reifiedBcs = {reified_bcs_init}
                 return {{
-                  typeName: {name}.$typeName,
-                  fullTypeName: composeSuiType(
-                    {name}.$typeName,
-                    ...[{extract_types}]
-                  ) as {full_type_as_type_with_generics},
-                  typeArgs: [{extract_types}] as {type_args_as_phantom},
+                  get typeName() {{ return {name}.$typeName }},
+                  get fullTypeName() {{
+                    return composeSuiType(
+                      {name}.$typeName,
+                      ...[{extract_types}]
+                    ) as {full_type_as_type_with_generics}
+                  }},
+                  get typeArgs() {{ return [{extract_types}] as {type_args_as_phantom} }},
                   isPhantom: {name}.$isPhantom,
                   reifiedTypeArgs: [{reified_arg_names}],
                   fromFields: (fields: Record<string, any>) => {name}.fromFields({reified_args_for_static}, fields),
@@ -1152,7 +1186,7 @@ impl StructIR {
               }}
             }}"#,
             name = self.name,
-            full_type_template = full_type_template,
+            type_name_decl = type_name_decl,
             num_type_params = num_type_params,
             type_param_extends = type_param_extends,
             type_params_use = type_params_use,

--- a/generator/tests/snapshot_tests.rs
+++ b/generator/tests/snapshot_tests.rs
@@ -29,14 +29,12 @@ fn examples_pkg_for(module_type_path: &str) -> PackageInfo {
     }
 }
 
-#[allow(dead_code)]
 fn sui_pkg() -> PackageInfo {
     PackageInfo::System {
         address: "0x2".to_string(),
     }
 }
 
-#[allow(dead_code)]
 fn stdlib_pkg() -> PackageInfo {
     PackageInfo::System {
         address: "0x1".to_string(),
@@ -2364,4 +2362,149 @@ fn test_struct_doc_escaping_snapshot() {
     assert!(output.contains("*\\/"), "Doc comments should escape */ to *\\/");
 
     insta::assert_snapshot!("struct__doc_escaping", output);
+}
+
+// =============================================================================
+// System-package fixtures (env-independent addresses)
+// =============================================================================
+//
+// These cover the `static readonly $typeName = "0x..." as const` branch — System
+// packages (std at 0x1, sui at 0x2) keep the literal-typed field instead of the
+// dynamic getter used for Dynamic packages. They lock in the invariant that
+// System emission preserves precise literal type narrowing.
+
+/// `0x2::object::ID` shape — System struct, no type params.
+fn make_system_struct_ir() -> StructIR {
+    StructIR {
+        name: "ID".to_string(),
+        module_struct_path: "object::ID".to_string(),
+        package_info: sui_pkg(),
+        type_params: vec![],
+        fields: vec![FieldIR {
+            ts_name: "bytes".to_string(),
+            move_name: "bytes".to_string(),
+            field_type: FieldTypeIR::Primitive("address".to_string()),
+            doc_comment: None,
+        }],
+        struct_imports: vec![],
+        uses_vector: false,
+        uses_address: true,
+        uses_phantom_struct_args: false,
+        has_non_phantom_type_params: false,
+        uses_field_to_json: false,
+        doc_comment: None,
+    }
+}
+
+/// Synthetic System enum at `0x1::sample::Status` with two unit variants.
+fn make_system_enum_ir() -> EnumIR {
+    EnumIR {
+        name: "Status".to_string(),
+        module_enum_path: "sample::Status".to_string(),
+        package_info: stdlib_pkg(),
+        type_params: vec![],
+        variants: vec![
+            EnumVariantIR {
+                name: "Ready".to_string(),
+                fields: vec![],
+                is_tuple: false,
+                doc_comment: None,
+            },
+            EnumVariantIR {
+                name: "Pending".to_string(),
+                fields: vec![],
+                is_tuple: false,
+                doc_comment: None,
+            },
+        ],
+        uses_vector: false,
+        uses_address: false,
+        uses_phantom_struct_args: false,
+        doc_comment: None,
+    }
+}
+
+#[test]
+fn test_system_struct_keeps_static_readonly() {
+    let ir = make_system_struct_ir();
+    let output = ir.emit_body();
+
+    // System packages must keep `static readonly` with the literal address,
+    // preserving precise template-literal type narrowing.
+    assert!(
+        output.contains("static readonly $typeName: `0x2::object::ID` = `0x2::object::ID` as const"),
+        "System struct must keep static readonly with literal type; got:\n{}",
+        output
+    );
+    // The getter form is reserved for Dynamic packages.
+    assert!(
+        !output.contains("static get $typeName"),
+        "System struct must NOT emit a getter for $typeName"
+    );
+
+    insta::assert_snapshot!("system__struct_keeps_readonly", output);
+}
+
+#[test]
+fn test_system_enum_keeps_static_readonly() {
+    let ir = make_system_enum_ir();
+    let output = ir.emit_body();
+
+    // Same invariant for the parent enum class: System addresses are constant,
+    // so `static readonly` with the literal address is preserved.
+    assert!(
+        output
+            .contains("static readonly $typeName: `0x1::sample::Status` = `0x1::sample::Status` as const"),
+        "System enum must keep static readonly with literal type; got:\n{}",
+        output
+    );
+    // Variant classes always emit a delegating getter (`static get $typeName(): typeof Status.$typeName`)
+    // regardless of System/Dynamic — the variant resolves through the parent's
+    // value, which for System is the constant literal. That's still a `static get`
+    // declaration, so we only assert the parent shape here.
+
+    insta::assert_snapshot!("system__enum_keeps_readonly", output);
+}
+
+#[test]
+fn test_dynamic_struct_emits_typename_getter() {
+    let ir = make_fixture_dummy_ir();
+    let output = ir.emit_body();
+
+    // Dynamic packages must emit the getter form so $typeName reflects
+    // setActiveEnv() calls made after class load.
+    assert!(
+        output.contains("static get $typeName():"),
+        "Dynamic struct must emit `static get $typeName()`; got:\n{}",
+        output
+    );
+    assert!(
+        !output.contains("static readonly $typeName"),
+        "Dynamic struct must not emit `static readonly $typeName`"
+    );
+
+    // reified() return-object fields must also be getters so stored reified
+    // handles read live env values.
+    assert!(
+        output.contains("get typeName() { return Dummy.$typeName }"),
+        "Dynamic struct reified() must expose typeName as a getter"
+    );
+    assert!(
+        output.contains("get fullTypeName() {"),
+        "Dynamic struct reified() must expose fullTypeName as a getter"
+    );
+}
+
+#[test]
+fn test_dynamic_enum_variant_typename_delegates_via_getter() {
+    let ir = make_enums_action_ir();
+    let output = ir.emit_body();
+
+    // Variant classes must delegate to the enum's $typeName via a getter, not
+    // capture the value at class-load time.
+    assert!(
+        output.contains("static get $typeName(): typeof Action.$typeName { return Action.$typeName }"),
+        "Variant class must emit a delegating getter for $typeName; got:\n{}",
+        output
+    );
 }

--- a/generator/tests/snapshots/snapshot_tests__collision__same_name_different_packages.snap
+++ b/generator/tests/snapshots/snapshot_tests__collision__same_name_different_packages.snap
@@ -31,7 +31,9 @@ export type MultiCoinHolderJSON = {
 export class MultiCoinHolder implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::collision::MultiCoinHolder` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::collision::MultiCoinHolder` as const
+  static get $typeName(): `${string}::collision::MultiCoinHolder` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::collision::MultiCoinHolder` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -59,11 +61,13 @@ export class MultiCoinHolder implements StructClass {
   static reified(): MultiCoinHolderReified {
     const reifiedBcs = MultiCoinHolder.bcs
     return {
-      typeName: MultiCoinHolder.$typeName,
-      fullTypeName: composeSuiType(
-        MultiCoinHolder.$typeName,
-        ...[]
-      ) as `${string}::collision::MultiCoinHolder`,
+      get typeName() { return MultiCoinHolder.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          MultiCoinHolder.$typeName,
+          ...[]
+        ) as `${string}::collision::MultiCoinHolder`
+      },
       typeArgs: [] as [],
       isPhantom: MultiCoinHolder.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__enum__non_phantom_in_phantom_position.snap
+++ b/generator/tests/snapshots/snapshot_tests__enum__non_phantom_in_phantom_position.snap
@@ -33,7 +33,9 @@ export type ContainerReified<T1 extends TypeArgument, T2 extends PhantomTypeArgu
 >
 
 export class Container {
-  static readonly $typeName: string = `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::Container` as const
+  static get $typeName(): string {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::Container` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, true] as const
 
@@ -42,12 +44,14 @@ export class Container {
   ): ContainerReified<ToTypeArgument<T1>, ToPhantomTypeArgument<T2>> {
     const reifiedBcs = Container.bcs(toBcs(T1))
     return {
-      typeName: Container.$typeName,
-      fullTypeName: composeSuiType(
-        Container.$typeName,
-        ...[extractType(T1), extractType(T2)]
-      ) as string,
-      typeArgs: [extractType(T1), extractType(T2)] as [ToTypeStr<ToTypeArgument<T1>>, PhantomToTypeStr<ToPhantomTypeArgument<T2>>],
+      get typeName() { return Container.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Container.$typeName,
+          ...[extractType(T1), extractType(T2)]
+        ) as string
+      },
+      get typeArgs() { return [extractType(T1), extractType(T2)] as [ToTypeStr<ToTypeArgument<T1>>, PhantomToTypeStr<ToPhantomTypeArgument<T2>>] },
       isPhantom: Container.$isPhantom,
       reifiedTypeArgs: [T1, T2],
       fromFields: (fields: Record<string, any>) => Container.fromFields([T1, T2], fields),
@@ -213,7 +217,7 @@ export class ContainerEmpty<T1 extends TypeArgument, T2 extends PhantomTypeArgum
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Container.$typeName = Container.$typeName
+  static get $typeName(): typeof Container.$typeName { return Container.$typeName }
   static readonly $numTypeParams: typeof Container.$numTypeParams = Container.$numTypeParams
   static readonly $isPhantom: typeof Container.$isPhantom = Container.$isPhantom
   static readonly $variantName = 'Empty' as const
@@ -266,7 +270,7 @@ export class ContainerWithTable<T1 extends TypeArgument, T2 extends PhantomTypeA
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Container.$typeName = Container.$typeName
+  static get $typeName(): typeof Container.$typeName { return Container.$typeName }
   static readonly $numTypeParams: typeof Container.$numTypeParams = Container.$numTypeParams
   static readonly $isPhantom: typeof Container.$isPhantom = Container.$isPhantom
   static readonly $variantName = 'WithTable' as const

--- a/generator/tests/snapshots/snapshot_tests__enums__action.snap
+++ b/generator/tests/snapshots/snapshot_tests__enums__action.snap
@@ -36,7 +36,9 @@ export type ActionReified<T extends TypeArgument, U extends PhantomTypeArgument>
 >
 
 export class Action {
-  static readonly $typeName: string = `${getTypeOrigin('examples', 'example::ExampleStruct')}::enums::Action` as const
+  static get $typeName(): string {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::enums::Action` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, true] as const
 
@@ -45,12 +47,14 @@ export class Action {
   ): ActionReified<ToTypeArgument<T>, ToPhantomTypeArgument<U>> {
     const reifiedBcs = Action.bcs(toBcs(T))
     return {
-      typeName: Action.$typeName,
-      fullTypeName: composeSuiType(
-        Action.$typeName,
-        ...[extractType(T), extractType(U)]
-      ) as string,
-      typeArgs: [extractType(T), extractType(U)] as [ToTypeStr<ToTypeArgument<T>>, PhantomToTypeStr<ToPhantomTypeArgument<U>>],
+      get typeName() { return Action.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Action.$typeName,
+          ...[extractType(T), extractType(U)]
+        ) as string
+      },
+      get typeArgs() { return [extractType(T), extractType(U)] as [ToTypeStr<ToTypeArgument<T>>, PhantomToTypeStr<ToPhantomTypeArgument<U>>] },
       isPhantom: Action.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => Action.fromFields([T, U], fields),
@@ -255,7 +259,7 @@ export class ActionStop<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName { return Action.$typeName }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Stop' as const
@@ -314,7 +318,7 @@ export class ActionPause<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName { return Action.$typeName }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Pause' as const
@@ -386,7 +390,7 @@ export class ActionJump<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName { return Action.$typeName }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Jump' as const

--- a/generator/tests/snapshots/snapshot_tests__enums__wrapped.snap
+++ b/generator/tests/snapshots/snapshot_tests__enums__wrapped.snap
@@ -39,7 +39,9 @@ export type WrappedJSON<T extends TypeArgument, U extends TypeArgument, V extend
 export class Wrapped<T extends TypeArgument, U extends TypeArgument, V extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::enums::Wrapped` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::enums::Wrapped` as const
+  static get $typeName(): `${string}::enums::Wrapped` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::enums::Wrapped` as const
+  }
   static readonly $numTypeParams = 3
   static readonly $isPhantom = [false, false, false] as const
 
@@ -77,12 +79,14 @@ export class Wrapped<T extends TypeArgument, U extends TypeArgument, V extends T
   ): WrappedReified<ToTypeArgument<T>, ToTypeArgument<U>, ToTypeArgument<V>> {
     const reifiedBcs = Wrapped.bcs(toBcs(T), toBcs(U), toBcs(V))
     return {
-      typeName: Wrapped.$typeName,
-      fullTypeName: composeSuiType(
-        Wrapped.$typeName,
-        ...[extractType(T), extractType(U), extractType(V)]
-      ) as `${string}::enums::Wrapped<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}, ${ToTypeStr<ToTypeArgument<V>>}>`,
-      typeArgs: [extractType(T), extractType(U), extractType(V)] as [ToTypeStr<ToTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>, ToTypeStr<ToTypeArgument<V>>],
+      get typeName() { return Wrapped.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Wrapped.$typeName,
+          ...[extractType(T), extractType(U), extractType(V)]
+        ) as `${string}::enums::Wrapped<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}, ${ToTypeStr<ToTypeArgument<V>>}>`
+      },
+      get typeArgs() { return [extractType(T), extractType(U), extractType(V)] as [ToTypeStr<ToTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>, ToTypeStr<ToTypeArgument<V>>] },
       isPhantom: Wrapped.$isPhantom,
       reifiedTypeArgs: [T, U, V],
       fromFields: (fields: Record<string, any>) => Wrapped.fromFields([T, U, V], fields),

--- a/generator/tests/snapshots/snapshot_tests__fixture__bar.snap
+++ b/generator/tests/snapshots/snapshot_tests__fixture__bar.snap
@@ -27,7 +27,9 @@ export type BarJSON = {
 export class Bar implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Bar` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Bar` as const
+  static get $typeName(): `${string}::fixture::Bar` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Bar` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -51,11 +53,13 @@ export class Bar implements StructClass {
   static reified(): BarReified {
     const reifiedBcs = Bar.bcs
     return {
-      typeName: Bar.$typeName,
-      fullTypeName: composeSuiType(
-        Bar.$typeName,
-        ...[]
-      ) as `${string}::fixture::Bar`,
+      get typeName() { return Bar.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Bar.$typeName,
+          ...[]
+        ) as `${string}::fixture::Bar`
+      },
       typeArgs: [] as [],
       isPhantom: Bar.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__fixture__dummy.snap
+++ b/generator/tests/snapshots/snapshot_tests__fixture__dummy.snap
@@ -27,7 +27,9 @@ export type DummyJSON = {
 export class Dummy implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Dummy` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Dummy` as const
+  static get $typeName(): `${string}::fixture::Dummy` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Dummy` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -51,11 +53,13 @@ export class Dummy implements StructClass {
   static reified(): DummyReified {
     const reifiedBcs = Dummy.bcs
     return {
-      typeName: Dummy.$typeName,
-      fullTypeName: composeSuiType(
-        Dummy.$typeName,
-        ...[]
-      ) as `${string}::fixture::Dummy`,
+      get typeName() { return Dummy.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Dummy.$typeName,
+          ...[]
+        ) as `${string}::fixture::Dummy`
+      },
       typeArgs: [] as [],
       isPhantom: Dummy.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__fixture__foo.snap
+++ b/generator/tests/snapshots/snapshot_tests__fixture__foo.snap
@@ -53,7 +53,9 @@ export type FooJSON<T extends TypeArgument> = {
 export class Foo<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Foo` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Foo` as const
+  static get $typeName(): `${string}::fixture::Foo` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Foo` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -105,12 +107,14 @@ export class Foo<T extends TypeArgument> implements StructClass {
   ): FooReified<ToTypeArgument<T>> {
     const reifiedBcs = Foo.bcs(toBcs(T))
     return {
-      typeName: Foo.$typeName,
-      fullTypeName: composeSuiType(
-        Foo.$typeName,
-        ...[extractType(T)]
-      ) as `${string}::fixture::Foo<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() { return Foo.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Foo.$typeName,
+          ...[extractType(T)]
+        ) as `${string}::fixture::Foo<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() { return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>] },
       isPhantom: Foo.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Foo.fromFields(T, fields),

--- a/generator/tests/snapshots/snapshot_tests__fixture__with_generic_field.snap
+++ b/generator/tests/snapshots/snapshot_tests__fixture__with_generic_field.snap
@@ -29,7 +29,9 @@ export type WithGenericFieldJSON<T extends TypeArgument> = {
 export class WithGenericField<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithGenericField` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithGenericField` as const
+  static get $typeName(): `${string}::fixture::WithGenericField` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithGenericField` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -57,12 +59,14 @@ export class WithGenericField<T extends TypeArgument> implements StructClass {
   ): WithGenericFieldReified<ToTypeArgument<T>> {
     const reifiedBcs = WithGenericField.bcs(toBcs(T))
     return {
-      typeName: WithGenericField.$typeName,
-      fullTypeName: composeSuiType(
-        WithGenericField.$typeName,
-        ...[extractType(T)]
-      ) as `${string}::fixture::WithGenericField<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() { return WithGenericField.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WithGenericField.$typeName,
+          ...[extractType(T)]
+        ) as `${string}::fixture::WithGenericField<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() { return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>] },
       isPhantom: WithGenericField.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => WithGenericField.fromFields(T, fields),

--- a/generator/tests/snapshots/snapshot_tests__fixture__with_special_types.snap
+++ b/generator/tests/snapshots/snapshot_tests__fixture__with_special_types.snap
@@ -51,7 +51,9 @@ export type WithSpecialTypesJSON<T extends PhantomTypeArgument, U extends TypeAr
 export class WithSpecialTypes<T extends PhantomTypeArgument, U extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypes` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithSpecialTypes` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypes` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithSpecialTypes` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [true, false] as const
 
@@ -101,12 +103,14 @@ export class WithSpecialTypes<T extends PhantomTypeArgument, U extends TypeArgum
   ): WithSpecialTypesReified<ToPhantomTypeArgument<T>, ToTypeArgument<U>> {
     const reifiedBcs = WithSpecialTypes.bcs(toBcs(U))
     return {
-      typeName: WithSpecialTypes.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypes.$typeName,
-        ...[extractType(T), extractType(U)]
-      ) as `${string}::fixture::WithSpecialTypes<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}>`,
-      typeArgs: [extractType(T), extractType(U)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>],
+      get typeName() { return WithSpecialTypes.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypes.$typeName,
+          ...[extractType(T), extractType(U)]
+        ) as `${string}::fixture::WithSpecialTypes<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}>`
+      },
+      get typeArgs() { return [extractType(T), extractType(U)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>] },
       isPhantom: WithSpecialTypes.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => WithSpecialTypes.fromFields([T, U], fields),

--- a/generator/tests/snapshots/snapshot_tests__fixture__with_special_types_in_vectors.snap
+++ b/generator/tests/snapshots/snapshot_tests__fixture__with_special_types_in_vectors.snap
@@ -39,7 +39,9 @@ export type WithSpecialTypesInVectorsJSON<T extends TypeArgument> = {
 export class WithSpecialTypesInVectors<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypesInVectors` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithSpecialTypesInVectors` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypesInVectors` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithSpecialTypesInVectors` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -77,12 +79,14 @@ export class WithSpecialTypesInVectors<T extends TypeArgument> implements Struct
   ): WithSpecialTypesInVectorsReified<ToTypeArgument<T>> {
     const reifiedBcs = WithSpecialTypesInVectors.bcs(toBcs(T))
     return {
-      typeName: WithSpecialTypesInVectors.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypesInVectors.$typeName,
-        ...[extractType(T)]
-      ) as `${string}::fixture::WithSpecialTypesInVectors<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() { return WithSpecialTypesInVectors.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypesInVectors.$typeName,
+          ...[extractType(T)]
+        ) as `${string}::fixture::WithSpecialTypesInVectors<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() { return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>] },
       isPhantom: WithSpecialTypesInVectors.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => WithSpecialTypesInVectors.fromFields(T, fields),

--- a/generator/tests/snapshots/snapshot_tests__fixture__with_two_generics.snap
+++ b/generator/tests/snapshots/snapshot_tests__fixture__with_two_generics.snap
@@ -29,7 +29,9 @@ export type WithTwoGenericsJSON<T extends TypeArgument, U extends TypeArgument> 
 export class WithTwoGenerics<T extends TypeArgument, U extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithTwoGenerics` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithTwoGenerics` as const
+  static get $typeName(): `${string}::fixture::WithTwoGenerics` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithTwoGenerics` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, false] as const
 
@@ -57,12 +59,14 @@ export class WithTwoGenerics<T extends TypeArgument, U extends TypeArgument> imp
   ): WithTwoGenericsReified<ToTypeArgument<T>, ToTypeArgument<U>> {
     const reifiedBcs = WithTwoGenerics.bcs(toBcs(T), toBcs(U))
     return {
-      typeName: WithTwoGenerics.$typeName,
-      fullTypeName: composeSuiType(
-        WithTwoGenerics.$typeName,
-        ...[extractType(T), extractType(U)]
-      ) as `${string}::fixture::WithTwoGenerics<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}>`,
-      typeArgs: [extractType(T), extractType(U)] as [ToTypeStr<ToTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>],
+      get typeName() { return WithTwoGenerics.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WithTwoGenerics.$typeName,
+          ...[extractType(T), extractType(U)]
+        ) as `${string}::fixture::WithTwoGenerics<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}>`
+      },
+      get typeArgs() { return [extractType(T), extractType(U)] as [ToTypeStr<ToTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>] },
       isPhantom: WithTwoGenerics.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => WithTwoGenerics.fromFields([T, U], fields),

--- a/generator/tests/snapshots/snapshot_tests__module__collision.snap
+++ b/generator/tests/snapshots/snapshot_tests__module__collision.snap
@@ -60,7 +60,9 @@ export type MultiCoinHolderJSON = {
 export class MultiCoinHolder implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::collision::MultiCoinHolder` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::collision::MultiCoinHolder` as const
+  static get $typeName(): `${string}::collision::MultiCoinHolder` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::collision::MultiCoinHolder` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -88,11 +90,13 @@ export class MultiCoinHolder implements StructClass {
   static reified(): MultiCoinHolderReified {
     const reifiedBcs = MultiCoinHolder.bcs
     return {
-      typeName: MultiCoinHolder.$typeName,
-      fullTypeName: composeSuiType(
-        MultiCoinHolder.$typeName,
-        ...[]
-      ) as `${string}::collision::MultiCoinHolder`,
+      get typeName() { return MultiCoinHolder.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          MultiCoinHolder.$typeName,
+          ...[]
+        ) as `${string}::collision::MultiCoinHolder`
+      },
       typeArgs: [] as [],
       isPhantom: MultiCoinHolder.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__module__enum_non_phantom_in_phantom_position.snap
+++ b/generator/tests/snapshots/snapshot_tests__module__enum_non_phantom_in_phantom_position.snap
@@ -69,7 +69,9 @@ export type ContainerReified<T1 extends TypeArgument, T2 extends PhantomTypeArgu
 >
 
 export class Container {
-  static readonly $typeName: string = `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::Container` as const
+  static get $typeName(): string {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::Container` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, true] as const
 
@@ -78,12 +80,14 @@ export class Container {
   ): ContainerReified<ToTypeArgument<T1>, ToPhantomTypeArgument<T2>> {
     const reifiedBcs = Container.bcs(toBcs(T1))
     return {
-      typeName: Container.$typeName,
-      fullTypeName: composeSuiType(
-        Container.$typeName,
-        ...[extractType(T1), extractType(T2)]
-      ) as string,
-      typeArgs: [extractType(T1), extractType(T2)] as [ToTypeStr<ToTypeArgument<T1>>, PhantomToTypeStr<ToPhantomTypeArgument<T2>>],
+      get typeName() { return Container.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Container.$typeName,
+          ...[extractType(T1), extractType(T2)]
+        ) as string
+      },
+      get typeArgs() { return [extractType(T1), extractType(T2)] as [ToTypeStr<ToTypeArgument<T1>>, PhantomToTypeStr<ToPhantomTypeArgument<T2>>] },
       isPhantom: Container.$isPhantom,
       reifiedTypeArgs: [T1, T2],
       fromFields: (fields: Record<string, any>) => Container.fromFields([T1, T2], fields),
@@ -249,7 +253,7 @@ export class ContainerEmpty<T1 extends TypeArgument, T2 extends PhantomTypeArgum
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Container.$typeName = Container.$typeName
+  static get $typeName(): typeof Container.$typeName { return Container.$typeName }
   static readonly $numTypeParams: typeof Container.$numTypeParams = Container.$numTypeParams
   static readonly $isPhantom: typeof Container.$isPhantom = Container.$isPhantom
   static readonly $variantName = 'Empty' as const
@@ -302,7 +306,7 @@ export class ContainerWithTable<T1 extends TypeArgument, T2 extends PhantomTypeA
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Container.$typeName = Container.$typeName
+  static get $typeName(): typeof Container.$typeName { return Container.$typeName }
   static readonly $numTypeParams: typeof Container.$numTypeParams = Container.$numTypeParams
   static readonly $isPhantom: typeof Container.$isPhantom = Container.$isPhantom
   static readonly $variantName = 'WithTable' as const

--- a/generator/tests/snapshots/snapshot_tests__module__enums.snap
+++ b/generator/tests/snapshots/snapshot_tests__module__enums.snap
@@ -79,7 +79,9 @@ export type WrappedJSON<T extends TypeArgument, U extends TypeArgument, V extend
 export class Wrapped<T extends TypeArgument, U extends TypeArgument, V extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::enums::Wrapped` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::enums::Wrapped` as const
+  static get $typeName(): `${string}::enums::Wrapped` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::enums::Wrapped` as const
+  }
   static readonly $numTypeParams = 3
   static readonly $isPhantom = [false, false, false] as const
 
@@ -117,12 +119,14 @@ export class Wrapped<T extends TypeArgument, U extends TypeArgument, V extends T
   ): WrappedReified<ToTypeArgument<T>, ToTypeArgument<U>, ToTypeArgument<V>> {
     const reifiedBcs = Wrapped.bcs(toBcs(T), toBcs(U), toBcs(V))
     return {
-      typeName: Wrapped.$typeName,
-      fullTypeName: composeSuiType(
-        Wrapped.$typeName,
-        ...[extractType(T), extractType(U), extractType(V)]
-      ) as `${string}::enums::Wrapped<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}, ${ToTypeStr<ToTypeArgument<V>>}>`,
-      typeArgs: [extractType(T), extractType(U), extractType(V)] as [ToTypeStr<ToTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>, ToTypeStr<ToTypeArgument<V>>],
+      get typeName() { return Wrapped.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Wrapped.$typeName,
+          ...[extractType(T), extractType(U), extractType(V)]
+        ) as `${string}::enums::Wrapped<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}, ${ToTypeStr<ToTypeArgument<V>>}>`
+      },
+      get typeArgs() { return [extractType(T), extractType(U), extractType(V)] as [ToTypeStr<ToTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>, ToTypeStr<ToTypeArgument<V>>] },
       isPhantom: Wrapped.$isPhantom,
       reifiedTypeArgs: [T, U, V],
       fromFields: (fields: Record<string, any>) => Wrapped.fromFields([T, U, V], fields),
@@ -378,7 +382,9 @@ export type ActionReified<T extends TypeArgument, U extends PhantomTypeArgument>
 >
 
 export class Action {
-  static readonly $typeName: string = `${getTypeOrigin('examples', 'example::ExampleStruct')}::enums::Action` as const
+  static get $typeName(): string {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::enums::Action` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, true] as const
 
@@ -387,12 +393,14 @@ export class Action {
   ): ActionReified<ToTypeArgument<T>, ToPhantomTypeArgument<U>> {
     const reifiedBcs = Action.bcs(toBcs(T))
     return {
-      typeName: Action.$typeName,
-      fullTypeName: composeSuiType(
-        Action.$typeName,
-        ...[extractType(T), extractType(U)]
-      ) as string,
-      typeArgs: [extractType(T), extractType(U)] as [ToTypeStr<ToTypeArgument<T>>, PhantomToTypeStr<ToPhantomTypeArgument<U>>],
+      get typeName() { return Action.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Action.$typeName,
+          ...[extractType(T), extractType(U)]
+        ) as string
+      },
+      get typeArgs() { return [extractType(T), extractType(U)] as [ToTypeStr<ToTypeArgument<T>>, PhantomToTypeStr<ToPhantomTypeArgument<U>>] },
       isPhantom: Action.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => Action.fromFields([T, U], fields),
@@ -597,7 +605,7 @@ export class ActionStop<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName { return Action.$typeName }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Stop' as const
@@ -656,7 +664,7 @@ export class ActionPause<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName { return Action.$typeName }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Pause' as const
@@ -728,7 +736,7 @@ export class ActionJump<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName { return Action.$typeName }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Jump' as const

--- a/generator/tests/snapshots/snapshot_tests__module__fixture_core.snap
+++ b/generator/tests/snapshots/snapshot_tests__module__fixture_core.snap
@@ -60,7 +60,9 @@ export type DummyJSON = {
 export class Dummy implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Dummy` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Dummy` as const
+  static get $typeName(): `${string}::fixture::Dummy` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Dummy` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -84,11 +86,13 @@ export class Dummy implements StructClass {
   static reified(): DummyReified {
     const reifiedBcs = Dummy.bcs
     return {
-      typeName: Dummy.$typeName,
-      fullTypeName: composeSuiType(
-        Dummy.$typeName,
-        ...[]
-      ) as `${string}::fixture::Dummy`,
+      get typeName() { return Dummy.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Dummy.$typeName,
+          ...[]
+        ) as `${string}::fixture::Dummy`
+      },
       typeArgs: [] as [],
       isPhantom: Dummy.$isPhantom,
       reifiedTypeArgs: [],
@@ -240,7 +244,9 @@ export type BarJSON = {
 export class Bar implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Bar` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Bar` as const
+  static get $typeName(): `${string}::fixture::Bar` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::Bar` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -264,11 +270,13 @@ export class Bar implements StructClass {
   static reified(): BarReified {
     const reifiedBcs = Bar.bcs
     return {
-      typeName: Bar.$typeName,
-      fullTypeName: composeSuiType(
-        Bar.$typeName,
-        ...[]
-      ) as `${string}::fixture::Bar`,
+      get typeName() { return Bar.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          Bar.$typeName,
+          ...[]
+        ) as `${string}::fixture::Bar`
+      },
       typeArgs: [] as [],
       isPhantom: Bar.$isPhantom,
       reifiedTypeArgs: [],
@@ -422,7 +430,9 @@ export type WithGenericFieldJSON<T extends TypeArgument> = {
 export class WithGenericField<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithGenericField` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithGenericField` as const
+  static get $typeName(): `${string}::fixture::WithGenericField` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithGenericField` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -450,12 +460,14 @@ export class WithGenericField<T extends TypeArgument> implements StructClass {
   ): WithGenericFieldReified<ToTypeArgument<T>> {
     const reifiedBcs = WithGenericField.bcs(toBcs(T))
     return {
-      typeName: WithGenericField.$typeName,
-      fullTypeName: composeSuiType(
-        WithGenericField.$typeName,
-        ...[extractType(T)]
-      ) as `${string}::fixture::WithGenericField<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() { return WithGenericField.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WithGenericField.$typeName,
+          ...[extractType(T)]
+        ) as `${string}::fixture::WithGenericField<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() { return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>] },
       isPhantom: WithGenericField.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => WithGenericField.fromFields(T, fields),
@@ -680,7 +692,9 @@ export type WithTwoGenericsJSON<T extends TypeArgument, U extends TypeArgument> 
 export class WithTwoGenerics<T extends TypeArgument, U extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithTwoGenerics` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithTwoGenerics` as const
+  static get $typeName(): `${string}::fixture::WithTwoGenerics` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithTwoGenerics` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, false] as const
 
@@ -708,12 +722,14 @@ export class WithTwoGenerics<T extends TypeArgument, U extends TypeArgument> imp
   ): WithTwoGenericsReified<ToTypeArgument<T>, ToTypeArgument<U>> {
     const reifiedBcs = WithTwoGenerics.bcs(toBcs(T), toBcs(U))
     return {
-      typeName: WithTwoGenerics.$typeName,
-      fullTypeName: composeSuiType(
-        WithTwoGenerics.$typeName,
-        ...[extractType(T), extractType(U)]
-      ) as `${string}::fixture::WithTwoGenerics<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}>`,
-      typeArgs: [extractType(T), extractType(U)] as [ToTypeStr<ToTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>],
+      get typeName() { return WithTwoGenerics.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WithTwoGenerics.$typeName,
+          ...[extractType(T), extractType(U)]
+        ) as `${string}::fixture::WithTwoGenerics<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}>`
+      },
+      get typeArgs() { return [extractType(T), extractType(U)] as [ToTypeStr<ToTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>] },
       isPhantom: WithTwoGenerics.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => WithTwoGenerics.fromFields([T, U], fields),

--- a/generator/tests/snapshots/snapshot_tests__module__fixture_special_types.snap
+++ b/generator/tests/snapshots/snapshot_tests__module__fixture_special_types.snap
@@ -97,7 +97,9 @@ export type WithSpecialTypesJSON<T extends PhantomTypeArgument, U extends TypeAr
 export class WithSpecialTypes<T extends PhantomTypeArgument, U extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypes` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithSpecialTypes` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypes` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithSpecialTypes` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [true, false] as const
 
@@ -147,12 +149,14 @@ export class WithSpecialTypes<T extends PhantomTypeArgument, U extends TypeArgum
   ): WithSpecialTypesReified<ToPhantomTypeArgument<T>, ToTypeArgument<U>> {
     const reifiedBcs = WithSpecialTypes.bcs(toBcs(U))
     return {
-      typeName: WithSpecialTypes.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypes.$typeName,
-        ...[extractType(T), extractType(U)]
-      ) as `${string}::fixture::WithSpecialTypes<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}>`,
-      typeArgs: [extractType(T), extractType(U)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>],
+      get typeName() { return WithSpecialTypes.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypes.$typeName,
+          ...[extractType(T), extractType(U)]
+        ) as `${string}::fixture::WithSpecialTypes<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}, ${ToTypeStr<ToTypeArgument<U>>}>`
+      },
+      get typeArgs() { return [extractType(T), extractType(U)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>, ToTypeStr<ToTypeArgument<U>>] },
       isPhantom: WithSpecialTypes.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => WithSpecialTypes.fromFields([T, U], fields),
@@ -441,7 +445,9 @@ export type WithSpecialTypesInVectorsJSON<T extends TypeArgument> = {
 export class WithSpecialTypesInVectors<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypesInVectors` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithSpecialTypesInVectors` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypesInVectors` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::fixture::WithSpecialTypesInVectors` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -479,12 +485,14 @@ export class WithSpecialTypesInVectors<T extends TypeArgument> implements Struct
   ): WithSpecialTypesInVectorsReified<ToTypeArgument<T>> {
     const reifiedBcs = WithSpecialTypesInVectors.bcs(toBcs(T))
     return {
-      typeName: WithSpecialTypesInVectors.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypesInVectors.$typeName,
-        ...[extractType(T)]
-      ) as `${string}::fixture::WithSpecialTypesInVectors<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() { return WithSpecialTypesInVectors.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypesInVectors.$typeName,
+          ...[extractType(T)]
+        ) as `${string}::fixture::WithSpecialTypesInVectors<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() { return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>] },
       isPhantom: WithSpecialTypesInVectors.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => WithSpecialTypesInVectors.fromFields(T, fields),

--- a/generator/tests/snapshots/snapshot_tests__module__non_phantom_in_phantom_position.snap
+++ b/generator/tests/snapshots/snapshot_tests__module__non_phantom_in_phantom_position.snap
@@ -66,7 +66,9 @@ export type WitTableJSON<T0 extends PhantomTypeArgument, T1 extends TypeArgument
 export class WitTable<T0 extends PhantomTypeArgument, T1 extends TypeArgument, T2 extends PhantomTypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::wit_table::WitTable` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::wit_table::WitTable` as const
+  static get $typeName(): `${string}::wit_table::WitTable` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::wit_table::WitTable` as const
+  }
   static readonly $numTypeParams = 3
   static readonly $isPhantom = [true, false, true] as const
 
@@ -94,12 +96,14 @@ export class WitTable<T0 extends PhantomTypeArgument, T1 extends TypeArgument, T
   ): WitTableReified<ToPhantomTypeArgument<T0>, ToTypeArgument<T1>, ToPhantomTypeArgument<T2>> {
     const reifiedBcs = WitTable.bcs(toBcs(T1))
     return {
-      typeName: WitTable.$typeName,
-      fullTypeName: composeSuiType(
-        WitTable.$typeName,
-        ...[extractType(T0), extractType(T1), extractType(T2)]
-      ) as `${string}::wit_table::WitTable<${PhantomToTypeStr<ToPhantomTypeArgument<T0>>}, ${ToTypeStr<ToTypeArgument<T1>>}, ${PhantomToTypeStr<ToPhantomTypeArgument<T2>>}>`,
-      typeArgs: [extractType(T0), extractType(T1), extractType(T2)] as [PhantomToTypeStr<ToPhantomTypeArgument<T0>>, ToTypeStr<ToTypeArgument<T1>>, PhantomToTypeStr<ToPhantomTypeArgument<T2>>],
+      get typeName() { return WitTable.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WitTable.$typeName,
+          ...[extractType(T0), extractType(T1), extractType(T2)]
+        ) as `${string}::wit_table::WitTable<${PhantomToTypeStr<ToPhantomTypeArgument<T0>>}, ${ToTypeStr<ToTypeArgument<T1>>}, ${PhantomToTypeStr<ToPhantomTypeArgument<T2>>}>`
+      },
+      get typeArgs() { return [extractType(T0), extractType(T1), extractType(T2)] as [PhantomToTypeStr<ToPhantomTypeArgument<T0>>, ToTypeStr<ToTypeArgument<T1>>, PhantomToTypeStr<ToPhantomTypeArgument<T2>>] },
       isPhantom: WitTable.$isPhantom,
       reifiedTypeArgs: [T0, T1, T2],
       fromFields: (fields: Record<string, any>) => WitTable.fromFields([T0, T1, T2], fields),

--- a/generator/tests/snapshots/snapshot_tests__module__with_phantom_type_args.snap
+++ b/generator/tests/snapshots/snapshot_tests__module__with_phantom_type_args.snap
@@ -53,7 +53,9 @@ export type ACLJSON = {
 export class ACL implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::acl::ACL` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::acl::ACL` as const
+  static get $typeName(): `${string}::acl::ACL` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::acl::ACL` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -77,11 +79,13 @@ export class ACL implements StructClass {
   static reified(): ACLReified {
     const reifiedBcs = ACL.bcs
     return {
-      typeName: ACL.$typeName,
-      fullTypeName: composeSuiType(
-        ACL.$typeName,
-        ...[]
-      ) as `${string}::acl::ACL`,
+      get typeName() { return ACL.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          ACL.$typeName,
+          ...[]
+        ) as `${string}::acl::ACL`
+      },
       typeArgs: [] as [],
       isPhantom: ACL.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__struct__doc_escaping.snap
+++ b/generator/tests/snapshots/snapshot_tests__struct__doc_escaping.snap
@@ -29,7 +29,9 @@ export type EscapedDocJSON = {
 export class EscapedDoc implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::test::EscapedDoc` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::EscapedDoc` as const
+  static get $typeName(): `${string}::test::EscapedDoc` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::EscapedDoc` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -54,11 +56,13 @@ export class EscapedDoc implements StructClass {
   static reified(): EscapedDocReified {
     const reifiedBcs = EscapedDoc.bcs
     return {
-      typeName: EscapedDoc.$typeName,
-      fullTypeName: composeSuiType(
-        EscapedDoc.$typeName,
-        ...[]
-      ) as `${string}::test::EscapedDoc`,
+      get typeName() { return EscapedDoc.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          EscapedDoc.$typeName,
+          ...[]
+        ) as `${string}::test::EscapedDoc`
+      },
       typeArgs: [] as [],
       isPhantom: EscapedDoc.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__struct__multiline_doc.snap
+++ b/generator/tests/snapshots/snapshot_tests__struct__multiline_doc.snap
@@ -37,7 +37,9 @@ export type MultilineDocJSON = {
 export class MultilineDoc implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::test::MultilineDoc` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::MultilineDoc` as const
+  static get $typeName(): `${string}::test::MultilineDoc` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::MultilineDoc` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -66,11 +68,13 @@ export class MultilineDoc implements StructClass {
   static reified(): MultilineDocReified {
     const reifiedBcs = MultilineDoc.bcs
     return {
-      typeName: MultilineDoc.$typeName,
-      fullTypeName: composeSuiType(
-        MultilineDoc.$typeName,
-        ...[]
-      ) as `${string}::test::MultilineDoc`,
+      get typeName() { return MultilineDoc.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          MultilineDoc.$typeName,
+          ...[]
+        ) as `${string}::test::MultilineDoc`
+      },
       typeArgs: [] as [],
       isPhantom: MultilineDoc.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__struct__non_phantom_in_phantom_position.snap
+++ b/generator/tests/snapshots/snapshot_tests__struct__non_phantom_in_phantom_position.snap
@@ -29,7 +29,9 @@ export type WitTableJSON<T0 extends PhantomTypeArgument, T1 extends TypeArgument
 export class WitTable<T0 extends PhantomTypeArgument, T1 extends TypeArgument, T2 extends PhantomTypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::wit_table::WitTable` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::wit_table::WitTable` as const
+  static get $typeName(): `${string}::wit_table::WitTable` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::wit_table::WitTable` as const
+  }
   static readonly $numTypeParams = 3
   static readonly $isPhantom = [true, false, true] as const
 
@@ -57,12 +59,14 @@ export class WitTable<T0 extends PhantomTypeArgument, T1 extends TypeArgument, T
   ): WitTableReified<ToPhantomTypeArgument<T0>, ToTypeArgument<T1>, ToPhantomTypeArgument<T2>> {
     const reifiedBcs = WitTable.bcs(toBcs(T1))
     return {
-      typeName: WitTable.$typeName,
-      fullTypeName: composeSuiType(
-        WitTable.$typeName,
-        ...[extractType(T0), extractType(T1), extractType(T2)]
-      ) as `${string}::wit_table::WitTable<${PhantomToTypeStr<ToPhantomTypeArgument<T0>>}, ${ToTypeStr<ToTypeArgument<T1>>}, ${PhantomToTypeStr<ToPhantomTypeArgument<T2>>}>`,
-      typeArgs: [extractType(T0), extractType(T1), extractType(T2)] as [PhantomToTypeStr<ToPhantomTypeArgument<T0>>, ToTypeStr<ToTypeArgument<T1>>, PhantomToTypeStr<ToPhantomTypeArgument<T2>>],
+      get typeName() { return WitTable.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          WitTable.$typeName,
+          ...[extractType(T0), extractType(T1), extractType(T2)]
+        ) as `${string}::wit_table::WitTable<${PhantomToTypeStr<ToPhantomTypeArgument<T0>>}, ${ToTypeStr<ToTypeArgument<T1>>}, ${PhantomToTypeStr<ToPhantomTypeArgument<T2>>}>`
+      },
+      get typeArgs() { return [extractType(T0), extractType(T1), extractType(T2)] as [PhantomToTypeStr<ToPhantomTypeArgument<T0>>, ToTypeStr<ToTypeArgument<T1>>, PhantomToTypeStr<ToPhantomTypeArgument<T2>>] },
       isPhantom: WitTable.$isPhantom,
       reifiedTypeArgs: [T0, T1, T2],
       fromFields: (fields: Record<string, any>) => WitTable.fromFields([T0, T1, T2], fields),

--- a/generator/tests/snapshots/snapshot_tests__struct__single_line_doc.snap
+++ b/generator/tests/snapshots/snapshot_tests__struct__single_line_doc.snap
@@ -29,7 +29,9 @@ export type DocumentedStructJSON = {
 export class DocumentedStruct implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::test::DocumentedStruct` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::DocumentedStruct` as const
+  static get $typeName(): `${string}::test::DocumentedStruct` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::test::DocumentedStruct` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -54,11 +56,13 @@ export class DocumentedStruct implements StructClass {
   static reified(): DocumentedStructReified {
     const reifiedBcs = DocumentedStruct.bcs
     return {
-      typeName: DocumentedStruct.$typeName,
-      fullTypeName: composeSuiType(
-        DocumentedStruct.$typeName,
-        ...[]
-      ) as `${string}::test::DocumentedStruct`,
+      get typeName() { return DocumentedStruct.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          DocumentedStruct.$typeName,
+          ...[]
+        ) as `${string}::test::DocumentedStruct`
+      },
       typeArgs: [] as [],
       isPhantom: DocumentedStruct.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__struct__with_phantom_type_args.snap
+++ b/generator/tests/snapshots/snapshot_tests__struct__with_phantom_type_args.snap
@@ -27,7 +27,9 @@ export type ACLJSON = {
 export class ACL implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::acl::ACL` = `${getTypeOrigin('examples', 'example::ExampleStruct')}::acl::ACL` as const
+  static get $typeName(): `${string}::acl::ACL` {
+    return `${getTypeOrigin('examples', 'example::ExampleStruct')}::acl::ACL` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -51,11 +53,13 @@ export class ACL implements StructClass {
   static reified(): ACLReified {
     const reifiedBcs = ACL.bcs
     return {
-      typeName: ACL.$typeName,
-      fullTypeName: composeSuiType(
-        ACL.$typeName,
-        ...[]
-      ) as `${string}::acl::ACL`,
+      get typeName() { return ACL.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          ACL.$typeName,
+          ...[]
+        ) as `${string}::acl::ACL`
+      },
       typeArgs: [] as [],
       isPhantom: ACL.$isPhantom,
       reifiedTypeArgs: [],

--- a/generator/tests/snapshots/snapshot_tests__system__enum_keeps_readonly.snap
+++ b/generator/tests/snapshots/snapshot_tests__system__enum_keeps_readonly.snap
@@ -1,0 +1,254 @@
+---
+source: generator/tests/snapshot_tests.rs
+expression: output
+---
+/* ============================== Status =============================== */
+
+export function isStatus(type: string): boolean {
+  type = compressSuiType(type)
+  return type === `0x1::sample::Status`
+}
+
+export type StatusVariant =
+  | StatusReady
+  | StatusPending
+
+export type StatusVariantJSON =
+  | StatusReadyJSON
+  | StatusPendingJSON
+
+export type StatusVariantName = 'Ready' | 'Pending'
+
+export function isStatusVariantName(variant: string): variant is StatusVariantName {
+  return variant === 'Ready' || variant === 'Pending'
+}
+
+export type StatusFields =
+  | StatusReadyFields
+  | StatusPendingFields
+
+export type StatusReified = Reified<
+  StatusVariant,
+  StatusFields
+>
+
+export class Status {
+  static readonly $typeName: `0x1::sample::Status` = `0x1::sample::Status` as const
+  static readonly $numTypeParams = 0
+  static readonly $isPhantom = [] as const
+
+  static reified(): StatusReified {
+    const reifiedBcs = Status.bcs
+    return {
+      get typeName() { return Status.$typeName },
+      get fullTypeName() { return composeSuiType(Status.$typeName) as `0x1::sample::Status` },
+      typeArgs: [] as [],
+      isPhantom: Status.$isPhantom,
+      reifiedTypeArgs: [],
+      fromFields: (fields: Record<string, any>) => Status.fromFields([], fields),
+      fromFieldsWithTypes: (item: FieldsWithTypes) => Status.fromFieldsWithTypes([], item),
+      fromBcs: (data: Uint8Array) => Status.fromBcs([], data),
+      bcs: reifiedBcs,
+      fromJSONField: (field: any) => Status.fromJSONField([], field),
+      fromJSON: (json: Record<string, any>) => Status.fromJSON([], json),
+      new: (variant: StatusVariantName, fields: StatusFields) => {
+        switch (variant) {
+          case 'Ready':
+            return new StatusReady([], fields as StatusReadyFields)
+          case 'Pending':
+            return new StatusPending([], fields as StatusPendingFields)
+        }
+      },
+      kind: 'EnumClassReified',
+    } as StatusReified
+  }
+
+  static get r(): typeof Status.reified {
+    return Status.reified
+  }
+
+  static phantom(): PhantomReified<ToTypeStr<StatusVariant>> {
+    return phantom(Status.reified())
+  }
+
+  static get p(): typeof Status.phantom {
+    return Status.phantom
+  }
+
+  private static instantiateBcs() {
+    return bcs.enum('Status', {
+      Ready: null,
+      Pending: null,
+    })
+  }
+
+  private static cachedBcs: ReturnType<typeof Status.instantiateBcs> | null = null
+
+  static get bcs(): ReturnType<typeof Status.instantiateBcs> {
+    if (!Status.cachedBcs) {
+      Status.cachedBcs = Status.instantiateBcs()
+    }
+    return Status.cachedBcs
+  }
+
+  static fromFields(typeArgs: [], fields: Record<string, any>): StatusVariant {
+    const r = Status.reified()
+
+    if (!fields.$kind || !isStatusVariantName(fields.$kind)) {
+      throw new Error(`Invalid status variant: ${fields.$kind}`)
+    }
+    switch (fields.$kind) {
+      case 'Ready':
+        return r.new('Ready', fields.Ready)
+      case 'Pending':
+        return r.new('Pending', fields.Pending)
+    }
+  }
+
+  static fromFieldsWithTypes(typeArgs: [], item: FieldsWithTypes): StatusVariant {
+    if (!isStatus(item.type)) {
+      throw new Error('not a Status type')
+    }
+
+    const variant = (item as FieldsWithTypes & { variant: StatusVariantName }).variant
+    if (!variant || !isStatusVariantName(variant)) {
+      throw new Error(`Invalid status variant: ${variant}`)
+    }
+
+    const r = Status.reified()
+    switch (variant) {
+      case 'Ready':
+        return r.new('Ready', {})
+      case 'Pending':
+        return r.new('Pending', {})
+    }
+  }
+
+  static fromBcs(typeArgs: [], data: Uint8Array): StatusVariant {
+    const parsed = Status.bcs.parse(data)
+    return Status.fromFields([], parsed)
+  }
+
+  static fromJSONField(typeArgs: [], field: any): StatusVariant {
+    const r = Status.reified()
+
+    const kind = field.$kind
+    if (!kind || !isStatusVariantName(kind)) {
+      throw new Error(`Invalid status variant: ${kind}`)
+    }
+    switch (kind) {
+      case 'Ready':
+        return r.new('Ready', {})
+      case 'Pending':
+        return r.new('Pending', {})
+    }
+  }
+
+  static fromJSON(typeArgs: [], json: Record<string, any>): StatusVariant {
+    if (json.$typeName !== Status.$typeName) {
+      throw new Error(`not a Status json object: expected '${Status.$typeName}' but got '${json.$typeName}'`)
+    }
+
+    return Status.fromJSONField(typeArgs, json)
+  }
+}
+
+export type StatusReadyFields = Record<string, never>
+
+export type StatusReadyJSONField = {
+  $kind: 'Ready'
+}
+
+export type StatusReadyJSON = {
+  $typeName: typeof Status.$typeName
+  $typeArgs: []
+  $variantName: 'Ready'
+} & StatusReadyJSONField
+
+export class StatusReady
+  implements EnumVariantClass
+{
+  __EnumVariantClass = true as const
+
+  static get $typeName(): typeof Status.$typeName { return Status.$typeName }
+  static readonly $numTypeParams: typeof Status.$numTypeParams = Status.$numTypeParams
+  static readonly $isPhantom: typeof Status.$isPhantom = Status.$isPhantom
+  static readonly $variantName = 'Ready' as const
+
+  readonly $typeName: typeof StatusReady.$typeName = StatusReady.$typeName
+  readonly $fullTypeName: `${typeof Status.$typeName}`
+  readonly $typeArgs: []
+  readonly $isPhantom: typeof Status.$isPhantom = Status.$isPhantom
+  readonly $variantName: typeof StatusReady.$variantName = StatusReady.$variantName
+
+  constructor(typeArgs: [], fields: StatusReadyFields) {
+    this.$fullTypeName = composeSuiType(
+      Status.$typeName,
+      ...typeArgs
+    ) as `${typeof Status.$typeName}`
+    this.$typeArgs = typeArgs
+  }
+
+  toJSONField(): StatusReadyJSONField {
+    return { $kind: this.$variantName }
+  }
+
+  toJSON(): StatusReadyJSON {
+    return {
+      $typeName: this.$typeName,
+      $typeArgs: this.$typeArgs,
+      $variantName: this.$variantName,
+      ...this.toJSONField(),
+    }
+  }
+}
+
+export type StatusPendingFields = Record<string, never>
+
+export type StatusPendingJSONField = {
+  $kind: 'Pending'
+}
+
+export type StatusPendingJSON = {
+  $typeName: typeof Status.$typeName
+  $typeArgs: []
+  $variantName: 'Pending'
+} & StatusPendingJSONField
+
+export class StatusPending
+  implements EnumVariantClass
+{
+  __EnumVariantClass = true as const
+
+  static get $typeName(): typeof Status.$typeName { return Status.$typeName }
+  static readonly $numTypeParams: typeof Status.$numTypeParams = Status.$numTypeParams
+  static readonly $isPhantom: typeof Status.$isPhantom = Status.$isPhantom
+  static readonly $variantName = 'Pending' as const
+
+  readonly $typeName: typeof StatusPending.$typeName = StatusPending.$typeName
+  readonly $fullTypeName: `${typeof Status.$typeName}`
+  readonly $typeArgs: []
+  readonly $isPhantom: typeof Status.$isPhantom = Status.$isPhantom
+  readonly $variantName: typeof StatusPending.$variantName = StatusPending.$variantName
+
+  constructor(typeArgs: [], fields: StatusPendingFields) {
+    this.$fullTypeName = composeSuiType(
+      Status.$typeName,
+      ...typeArgs
+    ) as `${typeof Status.$typeName}`
+    this.$typeArgs = typeArgs
+  }
+
+  toJSONField(): StatusPendingJSONField {
+    return { $kind: this.$variantName }
+  }
+
+  toJSON(): StatusPendingJSON {
+    return {
+      $typeName: this.$typeName,
+      $typeArgs: this.$typeArgs,
+      $variantName: this.$variantName,
+      ...this.toJSONField(),
+    }
+  }
+}

--- a/generator/tests/snapshots/snapshot_tests__system__struct_keeps_readonly.snap
+++ b/generator/tests/snapshots/snapshot_tests__system__struct_keeps_readonly.snap
@@ -1,0 +1,185 @@
+---
+source: generator/tests/snapshot_tests.rs
+expression: output
+---
+/* ============================== ID =============================== */
+
+export function isID(type: string): boolean {
+  type = compressSuiType(type)
+  return type === `0x2::object::ID`
+}
+
+export interface IDFields {
+  bytes: ToField<'address'>
+}
+
+export type IDReified = Reified<ID, IDFields>
+
+export type IDJSONField = {
+  bytes: string
+}
+
+export type IDJSON = {
+  $typeName: typeof ID.$typeName
+  $typeArgs: []
+} & IDJSONField
+
+export class ID implements StructClass {
+  __StructClass = true as const
+
+  static readonly $typeName: `0x2::object::ID` = `0x2::object::ID` as const
+  static readonly $numTypeParams = 0
+  static readonly $isPhantom = [] as const
+
+  readonly $typeName: typeof ID.$typeName = ID.$typeName
+  readonly $fullTypeName: `0x2::object::ID`
+  readonly $typeArgs: []
+  readonly $isPhantom: typeof ID.$isPhantom = ID.$isPhantom
+
+  readonly bytes: ToField<'address'>
+
+  private constructor(typeArgs: [], fields: IDFields) {
+    this.$fullTypeName = composeSuiType(
+      ID.$typeName,
+      ...typeArgs
+    ) as `0x2::object::ID`
+    this.$typeArgs = typeArgs
+
+    this.bytes = fields.bytes
+  }
+
+  static reified(): IDReified {
+    const reifiedBcs = ID.bcs
+    return {
+      get typeName() { return ID.$typeName },
+      get fullTypeName() {
+        return composeSuiType(
+          ID.$typeName,
+          ...[]
+        ) as `0x2::object::ID`
+      },
+      typeArgs: [] as [],
+      isPhantom: ID.$isPhantom,
+      reifiedTypeArgs: [],
+      fromFields: (fields: Record<string, any>) => ID.fromFields(fields),
+      fromFieldsWithTypes: (item: FieldsWithTypes) => ID.fromFieldsWithTypes(item),
+      fromBcs: (data: Uint8Array) => ID.fromFields(reifiedBcs.parse(data)),
+      bcs: reifiedBcs,
+      fromJSONField: (field: any) => ID.fromJSONField(field),
+      fromJSON: (json: Record<string, any>) => ID.fromJSON(json),
+      fromSuiParsedData: (content: SuiParsedData) => ID.fromSuiParsedData(content),
+      fromSuiObjectData: (content: SuiObjectData) => ID.fromSuiObjectData(content),
+      fetch: async (client: SupportedSuiClient, id: string) => ID.fetch(client, id),
+      new: (fields: IDFields) => {
+        return new ID([], fields)
+      },
+      kind: 'StructClassReified',
+    }
+  }
+
+  static get r(): IDReified {
+    return ID.reified()
+  }
+
+  static phantom(): PhantomReified<ToTypeStr<ID>> {
+    return phantom(ID.reified())
+  }
+
+  static get p(): PhantomReified<ToTypeStr<ID>> {
+    return ID.phantom()
+  }
+
+  private static instantiateBcs() {
+    return bcs.struct('ID', {
+      bytes: bcs.bytes(32).transform({ input: (val: string) => fromHex(val), output: (val: Uint8Array) => toHex(val) }),
+    })
+  }
+
+  private static cachedBcs: ReturnType<typeof ID.instantiateBcs> | null = null
+
+  static get bcs(): ReturnType<typeof ID.instantiateBcs> {
+    if (!ID.cachedBcs) {
+      ID.cachedBcs = ID.instantiateBcs()
+    }
+    return ID.cachedBcs
+  }
+
+  static fromFields(fields: Record<string, any>): ID {
+    return ID.reified().new({
+      bytes: decodeFromFields('address', fields.bytes),
+    })
+  }
+
+  static fromFieldsWithTypes(item: FieldsWithTypes): ID {
+    if (!isID(item.type)) {
+      throw new Error('not a ID type')
+    }
+
+    return ID.reified().new({
+      bytes: decodeFromFieldsWithTypes('address', item.fields.bytes),
+    })
+  }
+
+  static fromBcs(data: Uint8Array): ID {
+    return ID.fromFields(ID.bcs.parse(data))
+  }
+
+  toJSONField(): IDJSONField {
+    return {
+      bytes: this.bytes,
+    }
+  }
+
+  toJSON(): IDJSON {
+    return { $typeName: this.$typeName, $typeArgs: this.$typeArgs, ...this.toJSONField() }
+  }
+
+  static fromJSONField(field: any): ID {
+    return ID.reified().new({
+      bytes: decodeFromJSONField('address', field.bytes),
+    })
+  }
+
+  static fromJSON(json: Record<string, any>): ID {
+    if (json.$typeName !== ID.$typeName) {
+      throw new Error(`not a ID json object: expected '${ID.$typeName}' but got '${json.$typeName}'`)
+    }
+
+    return ID.fromJSONField(json)
+  }
+
+  static fromSuiParsedData(content: SuiParsedData): ID {
+    if (content.dataType !== 'moveObject') {
+      throw new Error('not an object')
+    }
+    if (!isID(content.type)) {
+      throw new Error(`object at ${(content.fields as any).id} is not a ID object`)
+    }
+    return ID.fromFieldsWithTypes(content)
+  }
+
+  static fromSuiObjectData(data: SuiObjectData): ID {
+    if (data.bcs) {
+      if (data.bcs.dataType !== 'moveObject' || !isID(data.bcs.type)) {
+        throw new Error(`object at is not a ID object`)
+      }
+
+      return ID.fromBcs(fromBase64(data.bcs.bcsBytes))
+    }
+    if (data.content) {
+      return ID.fromSuiParsedData(data.content)
+    }
+    throw new Error(
+      'Both `bcs` and `content` fields are missing from the data. Include `showBcs` or `showContent` in the request.'
+    )
+  }
+
+  static async fetch(client: SupportedSuiClient, id: string): Promise<ID> {
+    const res = await fetchObjectBcs(client, id)
+    if (!isID(res.type)) {
+      throw new Error(`object at id ${id} is not a ID object`)
+    }
+
+    return ID.fromBcs(res.bcsBytes)
+  }
+}

--- a/ts/examples/gen/_framework/env.ts
+++ b/ts/examples/gen/_framework/env.ts
@@ -71,9 +71,9 @@ export function getEnv(name: string): EnvConfig {
  *
  * @example
  *   const historical = cloneEnv(getEnv('mainnet'), {
- *     packages: { 'kai-leverage': { publishedAt: '0x...' } },
+ *     packages: { 'my-app': { publishedAt: '0x...' } },
  *   })
- *   createRebalanceReceipt(tx, typeArgs, args, { env: historical })
+ *   transfer(tx, typeArgs, args, { env: historical })
  */
 export function cloneEnv(
   base: EnvConfig,

--- a/ts/examples/gen/_framework/reified.ts
+++ b/ts/examples/gen/_framework/reified.ts
@@ -120,7 +120,7 @@ export type ToPhantomTypeArgument<T extends PhantomReified<PhantomTypeArgument>>
 export type PhantomTypeArgument = string
 
 export interface PhantomReified<P> {
-  phantomType: P
+  readonly phantomType: P
   kind: 'PhantomReified'
 }
 
@@ -135,8 +135,15 @@ export function phantom(type: string | Reified<TypeArgument, any>): PhantomReifi
       kind: 'PhantomReified',
     }
   } else {
+    // Reified handle case: read `fullTypeName` lazily so phantom handles created
+    // before `setActiveEnv(...)` still reflect the current env on each access.
+    // Without this getter, `phantomType` would freeze the typeName at phantom-call time
+    // and leak the wrong address into vector/option type-arg strings produced via
+    // `extractType(...)`.
     return {
-      phantomType: type.fullTypeName,
+      get phantomType() {
+        return type.fullTypeName
+      },
       kind: 'PhantomReified',
     }
   }

--- a/ts/examples/gen/amm/pool/structs.ts
+++ b/ts/examples/gen/amm/pool/structs.ts
@@ -59,9 +59,9 @@ export type PoolCreationEventJSON = {
 export class PoolCreationEvent implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::pool::PoolCreationEvent` = `${
-    getTypeOrigin('amm', 'pool::PoolCreationEvent')
-  }::pool::PoolCreationEvent` as const
+  static get $typeName(): `${string}::pool::PoolCreationEvent` {
+    return `${getTypeOrigin('amm', 'pool::PoolCreationEvent')}::pool::PoolCreationEvent` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -85,11 +85,15 @@ export class PoolCreationEvent implements StructClass {
   static reified(): PoolCreationEventReified {
     const reifiedBcs = PoolCreationEvent.bcs
     return {
-      typeName: PoolCreationEvent.$typeName,
-      fullTypeName: composeSuiType(
-        PoolCreationEvent.$typeName,
-        ...[],
-      ) as `${string}::pool::PoolCreationEvent`,
+      get typeName() {
+        return PoolCreationEvent.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PoolCreationEvent.$typeName,
+          ...[],
+        ) as `${string}::pool::PoolCreationEvent`
+      },
       typeArgs: [] as [],
       isPhantom: PoolCreationEvent.$isPhantom,
       reifiedTypeArgs: [],
@@ -249,9 +253,9 @@ export class LP<A extends PhantomTypeArgument, B extends PhantomTypeArgument>
 {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::pool::LP` = `${
-    getTypeOrigin('amm', 'pool::LP')
-  }::pool::LP` as const
+  static get $typeName(): `${string}::pool::LP` {
+    return `${getTypeOrigin('amm', 'pool::LP')}::pool::LP` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [true, true] as const
 
@@ -284,17 +288,23 @@ export class LP<A extends PhantomTypeArgument, B extends PhantomTypeArgument>
   ): LPReified<ToPhantomTypeArgument<A>, ToPhantomTypeArgument<B>> {
     const reifiedBcs = LP.bcs
     return {
-      typeName: LP.$typeName,
-      fullTypeName: composeSuiType(
-        LP.$typeName,
-        ...[extractType(A), extractType(B)],
-      ) as `${string}::pool::LP<${PhantomToTypeStr<ToPhantomTypeArgument<A>>}, ${PhantomToTypeStr<
-        ToPhantomTypeArgument<B>
-      >}>`,
-      typeArgs: [extractType(A), extractType(B)] as [
-        PhantomToTypeStr<ToPhantomTypeArgument<A>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<B>>,
-      ],
+      get typeName() {
+        return LP.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          LP.$typeName,
+          ...[extractType(A), extractType(B)],
+        ) as `${string}::pool::LP<${PhantomToTypeStr<ToPhantomTypeArgument<A>>}, ${PhantomToTypeStr<
+          ToPhantomTypeArgument<B>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(A), extractType(B)] as [
+          PhantomToTypeStr<ToPhantomTypeArgument<A>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<B>>,
+        ]
+      },
       isPhantom: LP.$isPhantom,
       reifiedTypeArgs: [A, B],
       fromFields: (fields: Record<string, any>) => LP.fromFields([A, B], fields),
@@ -564,9 +574,9 @@ export class Pool<A extends PhantomTypeArgument, B extends PhantomTypeArgument>
 {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::pool::Pool` = `${
-    getTypeOrigin('amm', 'pool::Pool')
-  }::pool::Pool` as const
+  static get $typeName(): `${string}::pool::Pool` {
+    return `${getTypeOrigin('amm', 'pool::Pool')}::pool::Pool` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [true, true] as const
 
@@ -617,17 +627,23 @@ export class Pool<A extends PhantomTypeArgument, B extends PhantomTypeArgument>
   ): PoolReified<ToPhantomTypeArgument<A>, ToPhantomTypeArgument<B>> {
     const reifiedBcs = Pool.bcs
     return {
-      typeName: Pool.$typeName,
-      fullTypeName: composeSuiType(
-        Pool.$typeName,
-        ...[extractType(A), extractType(B)],
-      ) as `${string}::pool::Pool<${PhantomToTypeStr<ToPhantomTypeArgument<A>>}, ${PhantomToTypeStr<
-        ToPhantomTypeArgument<B>
-      >}>`,
-      typeArgs: [extractType(A), extractType(B)] as [
-        PhantomToTypeStr<ToPhantomTypeArgument<A>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<B>>,
-      ],
+      get typeName() {
+        return Pool.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Pool.$typeName,
+          ...[extractType(A), extractType(B)],
+        ) as `${string}::pool::Pool<${PhantomToTypeStr<
+          ToPhantomTypeArgument<A>
+        >}, ${PhantomToTypeStr<ToPhantomTypeArgument<B>>}>`
+      },
+      get typeArgs() {
+        return [extractType(A), extractType(B)] as [
+          PhantomToTypeStr<ToPhantomTypeArgument<A>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<B>>,
+        ]
+      },
       isPhantom: Pool.$isPhantom,
       reifiedTypeArgs: [A, B],
       fromFields: (fields: Record<string, any>) => Pool.fromFields([A, B], fields),
@@ -927,9 +943,9 @@ export type PoolRegistryJSON = {
 export class PoolRegistry implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::pool::PoolRegistry` = `${
-    getTypeOrigin('amm', 'pool::PoolRegistry')
-  }::pool::PoolRegistry` as const
+  static get $typeName(): `${string}::pool::PoolRegistry` {
+    return `${getTypeOrigin('amm', 'pool::PoolRegistry')}::pool::PoolRegistry` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -955,11 +971,15 @@ export class PoolRegistry implements StructClass {
   static reified(): PoolRegistryReified {
     const reifiedBcs = PoolRegistry.bcs
     return {
-      typeName: PoolRegistry.$typeName,
-      fullTypeName: composeSuiType(
-        PoolRegistry.$typeName,
-        ...[],
-      ) as `${string}::pool::PoolRegistry`,
+      get typeName() {
+        return PoolRegistry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PoolRegistry.$typeName,
+          ...[],
+        ) as `${string}::pool::PoolRegistry`
+      },
       typeArgs: [] as [],
       isPhantom: PoolRegistry.$isPhantom,
       reifiedTypeArgs: [],
@@ -1130,9 +1150,9 @@ export type PoolRegistryItemJSON = {
 export class PoolRegistryItem implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::pool::PoolRegistryItem` = `${
-    getTypeOrigin('amm', 'pool::PoolRegistryItem')
-  }::pool::PoolRegistryItem` as const
+  static get $typeName(): `${string}::pool::PoolRegistryItem` {
+    return `${getTypeOrigin('amm', 'pool::PoolRegistryItem')}::pool::PoolRegistryItem` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -1158,11 +1178,15 @@ export class PoolRegistryItem implements StructClass {
   static reified(): PoolRegistryItemReified {
     const reifiedBcs = PoolRegistryItem.bcs
     return {
-      typeName: PoolRegistryItem.$typeName,
-      fullTypeName: composeSuiType(
-        PoolRegistryItem.$typeName,
-        ...[],
-      ) as `${string}::pool::PoolRegistryItem`,
+      get typeName() {
+        return PoolRegistryItem.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PoolRegistryItem.$typeName,
+          ...[],
+        ) as `${string}::pool::PoolRegistryItem`
+      },
       typeArgs: [] as [],
       isPhantom: PoolRegistryItem.$isPhantom,
       reifiedTypeArgs: [],
@@ -1326,9 +1350,9 @@ export type AdminCapJSON = {
 export class AdminCap implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::pool::AdminCap` = `${
-    getTypeOrigin('amm', 'pool::AdminCap')
-  }::pool::AdminCap` as const
+  static get $typeName(): `${string}::pool::AdminCap` {
+    return `${getTypeOrigin('amm', 'pool::AdminCap')}::pool::AdminCap` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -1352,11 +1376,15 @@ export class AdminCap implements StructClass {
   static reified(): AdminCapReified {
     const reifiedBcs = AdminCap.bcs
     return {
-      typeName: AdminCap.$typeName,
-      fullTypeName: composeSuiType(
-        AdminCap.$typeName,
-        ...[],
-      ) as `${string}::pool::AdminCap`,
+      get typeName() {
+        return AdminCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AdminCap.$typeName,
+          ...[],
+        ) as `${string}::pool::AdminCap`
+      },
       typeArgs: [] as [],
       isPhantom: AdminCap.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/examples/enums/structs.ts
+++ b/ts/examples/gen/examples/enums/structs.ts
@@ -87,9 +87,9 @@ export class Wrapped<T extends TypeArgument, U extends TypeArgument, V extends T
 {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::enums::Wrapped` = `${
-    getTypeOrigin('examples', 'enums::Wrapped')
-  }::enums::Wrapped` as const
+  static get $typeName(): `${string}::enums::Wrapped` {
+    return `${getTypeOrigin('examples', 'enums::Wrapped')}::enums::Wrapped` as const
+  }
   static readonly $numTypeParams = 3
   static readonly $isPhantom = [false, false, false] as const
 
@@ -138,18 +138,24 @@ export class Wrapped<T extends TypeArgument, U extends TypeArgument, V extends T
   ): WrappedReified<ToTypeArgument<T>, ToTypeArgument<U>, ToTypeArgument<V>> {
     const reifiedBcs = Wrapped.bcs(toBcs(T), toBcs(U), toBcs(V))
     return {
-      typeName: Wrapped.$typeName,
-      fullTypeName: composeSuiType(
-        Wrapped.$typeName,
-        ...[extractType(T), extractType(U), extractType(V)],
-      ) as `${string}::enums::Wrapped<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<
-        ToTypeArgument<U>
-      >}, ${ToTypeStr<ToTypeArgument<V>>}>`,
-      typeArgs: [extractType(T), extractType(U), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<T>>,
-        ToTypeStr<ToTypeArgument<U>>,
-        ToTypeStr<ToTypeArgument<V>>,
-      ],
+      get typeName() {
+        return Wrapped.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Wrapped.$typeName,
+          ...[extractType(T), extractType(U), extractType(V)],
+        ) as `${string}::enums::Wrapped<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<
+          ToTypeArgument<U>
+        >}, ${ToTypeStr<ToTypeArgument<V>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T), extractType(U), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<T>>,
+          ToTypeStr<ToTypeArgument<U>>,
+          ToTypeStr<ToTypeArgument<V>>,
+        ]
+      },
       isPhantom: Wrapped.$isPhantom,
       reifiedTypeArgs: [T, U, V],
       fromFields: (fields: Record<string, any>) => Wrapped.fromFields([T, U, V], fields),
@@ -461,9 +467,9 @@ export type ActionReified<T extends TypeArgument, U extends PhantomTypeArgument>
 >
 
 export class Action {
-  static readonly $typeName: string = `${
-    getTypeOrigin('examples', 'enums::Action')
-  }::enums::Action` as const
+  static get $typeName(): string {
+    return `${getTypeOrigin('examples', 'enums::Action')}::enums::Action` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, true] as const
 
@@ -476,15 +482,21 @@ export class Action {
   ): ActionReified<ToTypeArgument<T>, ToPhantomTypeArgument<U>> {
     const reifiedBcs = Action.bcs(toBcs(T))
     return {
-      typeName: Action.$typeName,
-      fullTypeName: composeSuiType(
-        Action.$typeName,
-        ...[extractType(T), extractType(U)],
-      ) as string,
-      typeArgs: [extractType(T), extractType(U)] as [
-        ToTypeStr<ToTypeArgument<T>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<U>>,
-      ],
+      get typeName() {
+        return Action.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Action.$typeName,
+          ...[extractType(T), extractType(U)],
+        ) as string
+      },
+      get typeArgs() {
+        return [extractType(T), extractType(U)] as [
+          ToTypeStr<ToTypeArgument<T>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<U>>,
+        ]
+      },
       isPhantom: Action.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => Action.fromFields([T, U], fields),
@@ -713,7 +725,9 @@ export class ActionStop<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName {
+    return Action.$typeName
+  }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Stop' as const
@@ -772,7 +786,9 @@ export class ActionPause<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName {
+    return Action.$typeName
+  }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Pause' as const
@@ -847,7 +863,9 @@ export class ActionJump<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName {
+    return Action.$typeName
+  }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Jump' as const

--- a/ts/examples/gen/examples/example-coin/structs.ts
+++ b/ts/examples/gen/examples/example-coin/structs.ts
@@ -51,9 +51,11 @@ export type EXAMPLE_COINJSON = {
 export class EXAMPLE_COIN implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::example_coin::EXAMPLE_COIN` = `${
-    getTypeOrigin('examples', 'example_coin::EXAMPLE_COIN')
-  }::example_coin::EXAMPLE_COIN` as const
+  static get $typeName(): `${string}::example_coin::EXAMPLE_COIN` {
+    return `${
+      getTypeOrigin('examples', 'example_coin::EXAMPLE_COIN')
+    }::example_coin::EXAMPLE_COIN` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -77,11 +79,15 @@ export class EXAMPLE_COIN implements StructClass {
   static reified(): EXAMPLE_COINReified {
     const reifiedBcs = EXAMPLE_COIN.bcs
     return {
-      typeName: EXAMPLE_COIN.$typeName,
-      fullTypeName: composeSuiType(
-        EXAMPLE_COIN.$typeName,
-        ...[],
-      ) as `${string}::example_coin::EXAMPLE_COIN`,
+      get typeName() {
+        return EXAMPLE_COIN.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          EXAMPLE_COIN.$typeName,
+          ...[],
+        ) as `${string}::example_coin::EXAMPLE_COIN`
+      },
       typeArgs: [] as [],
       isPhantom: EXAMPLE_COIN.$isPhantom,
       reifiedTypeArgs: [],
@@ -237,9 +243,9 @@ export type FaucetJSON = {
 export class Faucet implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::example_coin::Faucet` = `${
-    getTypeOrigin('examples', 'example_coin::Faucet')
-  }::example_coin::Faucet` as const
+  static get $typeName(): `${string}::example_coin::Faucet` {
+    return `${getTypeOrigin('examples', 'example_coin::Faucet')}::example_coin::Faucet` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -265,11 +271,15 @@ export class Faucet implements StructClass {
   static reified(): FaucetReified {
     const reifiedBcs = Faucet.bcs
     return {
-      typeName: Faucet.$typeName,
-      fullTypeName: composeSuiType(
-        Faucet.$typeName,
-        ...[],
-      ) as `${string}::example_coin::Faucet`,
+      get typeName() {
+        return Faucet.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Faucet.$typeName,
+          ...[],
+        ) as `${string}::example_coin::Faucet`
+      },
       typeArgs: [] as [],
       isPhantom: Faucet.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/examples/examples/structs.ts
+++ b/ts/examples/gen/examples/examples/structs.ts
@@ -54,9 +54,11 @@ export type ExampleStructJSON = {
 export class ExampleStruct implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::examples::ExampleStruct` = `${
-    getTypeOrigin('examples', 'examples::ExampleStruct')
-  }::examples::ExampleStruct` as const
+  static get $typeName(): `${string}::examples::ExampleStruct` {
+    return `${
+      getTypeOrigin('examples', 'examples::ExampleStruct')
+    }::examples::ExampleStruct` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -80,11 +82,15 @@ export class ExampleStruct implements StructClass {
   static reified(): ExampleStructReified {
     const reifiedBcs = ExampleStruct.bcs
     return {
-      typeName: ExampleStruct.$typeName,
-      fullTypeName: composeSuiType(
-        ExampleStruct.$typeName,
-        ...[],
-      ) as `${string}::examples::ExampleStruct`,
+      get typeName() {
+        return ExampleStruct.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ExampleStruct.$typeName,
+          ...[],
+        ) as `${string}::examples::ExampleStruct`
+      },
       typeArgs: [] as [],
       isPhantom: ExampleStruct.$isPhantom,
       reifiedTypeArgs: [],
@@ -255,9 +261,11 @@ export type SpecialTypesStructJSON = {
 export class SpecialTypesStruct implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::examples::SpecialTypesStruct` = `${
-    getTypeOrigin('examples', 'examples::SpecialTypesStruct')
-  }::examples::SpecialTypesStruct` as const
+  static get $typeName(): `${string}::examples::SpecialTypesStruct` {
+    return `${
+      getTypeOrigin('examples', 'examples::SpecialTypesStruct')
+    }::examples::SpecialTypesStruct` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -297,11 +305,15 @@ export class SpecialTypesStruct implements StructClass {
   static reified(): SpecialTypesStructReified {
     const reifiedBcs = SpecialTypesStruct.bcs
     return {
-      typeName: SpecialTypesStruct.$typeName,
-      fullTypeName: composeSuiType(
-        SpecialTypesStruct.$typeName,
-        ...[],
-      ) as `${string}::examples::SpecialTypesStruct`,
+      get typeName() {
+        return SpecialTypesStruct.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          SpecialTypesStruct.$typeName,
+          ...[],
+        ) as `${string}::examples::SpecialTypesStruct`
+      },
       typeArgs: [] as [],
       isPhantom: SpecialTypesStruct.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/examples/fixture/structs.ts
+++ b/ts/examples/gen/examples/fixture/structs.ts
@@ -69,9 +69,9 @@ export type DummyJSON = {
 export class Dummy implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Dummy` = `${
-    getTypeOrigin('examples', 'fixture::Dummy')
-  }::fixture::Dummy` as const
+  static get $typeName(): `${string}::fixture::Dummy` {
+    return `${getTypeOrigin('examples', 'fixture::Dummy')}::fixture::Dummy` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -95,11 +95,15 @@ export class Dummy implements StructClass {
   static reified(): DummyReified {
     const reifiedBcs = Dummy.bcs
     return {
-      typeName: Dummy.$typeName,
-      fullTypeName: composeSuiType(
-        Dummy.$typeName,
-        ...[],
-      ) as `${string}::fixture::Dummy`,
+      get typeName() {
+        return Dummy.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Dummy.$typeName,
+          ...[],
+        ) as `${string}::fixture::Dummy`
+      },
       typeArgs: [] as [],
       isPhantom: Dummy.$isPhantom,
       reifiedTypeArgs: [],
@@ -260,9 +264,11 @@ export type WithGenericFieldJSON<T extends TypeArgument> = {
 export class WithGenericField<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithGenericField` = `${
-    getTypeOrigin('examples', 'fixture::WithGenericField')
-  }::fixture::WithGenericField` as const
+  static get $typeName(): `${string}::fixture::WithGenericField` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithGenericField')
+    }::fixture::WithGenericField` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -290,12 +296,18 @@ export class WithGenericField<T extends TypeArgument> implements StructClass {
   ): WithGenericFieldReified<ToTypeArgument<T>> {
     const reifiedBcs = WithGenericField.bcs(toBcs(T))
     return {
-      typeName: WithGenericField.$typeName,
-      fullTypeName: composeSuiType(
-        WithGenericField.$typeName,
-        ...[extractType(T)],
-      ) as `${string}::fixture::WithGenericField<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return WithGenericField.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithGenericField.$typeName,
+          ...[extractType(T)],
+        ) as `${string}::fixture::WithGenericField<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: WithGenericField.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => WithGenericField.fromFields(T, fields),
@@ -521,9 +533,9 @@ export type BarJSON = {
 export class Bar implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Bar` = `${
-    getTypeOrigin('examples', 'fixture::Bar')
-  }::fixture::Bar` as const
+  static get $typeName(): `${string}::fixture::Bar` {
+    return `${getTypeOrigin('examples', 'fixture::Bar')}::fixture::Bar` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -547,11 +559,15 @@ export class Bar implements StructClass {
   static reified(): BarReified {
     const reifiedBcs = Bar.bcs
     return {
-      typeName: Bar.$typeName,
-      fullTypeName: composeSuiType(
-        Bar.$typeName,
-        ...[],
-      ) as `${string}::fixture::Bar`,
+      get typeName() {
+        return Bar.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Bar.$typeName,
+          ...[],
+        ) as `${string}::fixture::Bar`
+      },
       typeArgs: [] as [],
       isPhantom: Bar.$isPhantom,
       reifiedTypeArgs: [],
@@ -714,9 +730,11 @@ export class WithTwoGenerics<T extends TypeArgument, U extends TypeArgument>
 {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithTwoGenerics` = `${
-    getTypeOrigin('examples', 'fixture::WithTwoGenerics')
-  }::fixture::WithTwoGenerics` as const
+  static get $typeName(): `${string}::fixture::WithTwoGenerics` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithTwoGenerics')
+    }::fixture::WithTwoGenerics` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, false] as const
 
@@ -745,17 +763,23 @@ export class WithTwoGenerics<T extends TypeArgument, U extends TypeArgument>
   ): WithTwoGenericsReified<ToTypeArgument<T>, ToTypeArgument<U>> {
     const reifiedBcs = WithTwoGenerics.bcs(toBcs(T), toBcs(U))
     return {
-      typeName: WithTwoGenerics.$typeName,
-      fullTypeName: composeSuiType(
-        WithTwoGenerics.$typeName,
-        ...[extractType(T), extractType(U)],
-      ) as `${string}::fixture::WithTwoGenerics<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<
-        ToTypeArgument<U>
-      >}>`,
-      typeArgs: [extractType(T), extractType(U)] as [
-        ToTypeStr<ToTypeArgument<T>>,
-        ToTypeStr<ToTypeArgument<U>>,
-      ],
+      get typeName() {
+        return WithTwoGenerics.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithTwoGenerics.$typeName,
+          ...[extractType(T), extractType(U)],
+        ) as `${string}::fixture::WithTwoGenerics<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<
+          ToTypeArgument<U>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T), extractType(U)] as [
+          ToTypeStr<ToTypeArgument<T>>,
+          ToTypeStr<ToTypeArgument<U>>,
+        ]
+      },
       isPhantom: WithTwoGenerics.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => WithTwoGenerics.fromFields([T, U], fields),
@@ -1022,9 +1046,9 @@ export type FooJSON<T extends TypeArgument> = {
 export class Foo<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Foo` = `${
-    getTypeOrigin('examples', 'fixture::Foo')
-  }::fixture::Foo` as const
+  static get $typeName(): `${string}::fixture::Foo` {
+    return `${getTypeOrigin('examples', 'fixture::Foo')}::fixture::Foo` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -1078,12 +1102,18 @@ export class Foo<T extends TypeArgument> implements StructClass {
   ): FooReified<ToTypeArgument<T>> {
     const reifiedBcs = Foo.bcs(toBcs(T))
     return {
-      typeName: Foo.$typeName,
-      fullTypeName: composeSuiType(
-        Foo.$typeName,
-        ...[extractType(T)],
-      ) as `${string}::fixture::Foo<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return Foo.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Foo.$typeName,
+          ...[extractType(T)],
+        ) as `${string}::fixture::Foo<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: Foo.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Foo.fromFields(T, fields),
@@ -1487,9 +1517,11 @@ export class WithSpecialTypes<T extends PhantomTypeArgument, U extends TypeArgum
 {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypes` = `${
-    getTypeOrigin('examples', 'fixture::WithSpecialTypes')
-  }::fixture::WithSpecialTypes` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypes` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithSpecialTypes')
+    }::fixture::WithSpecialTypes` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [true, false] as const
 
@@ -1548,17 +1580,23 @@ export class WithSpecialTypes<T extends PhantomTypeArgument, U extends TypeArgum
   ): WithSpecialTypesReified<ToPhantomTypeArgument<T>, ToTypeArgument<U>> {
     const reifiedBcs = WithSpecialTypes.bcs(toBcs(U))
     return {
-      typeName: WithSpecialTypes.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypes.$typeName,
-        ...[extractType(T), extractType(U)],
-      ) as `${string}::fixture::WithSpecialTypes<${PhantomToTypeStr<
-        ToPhantomTypeArgument<T>
-      >}, ${ToTypeStr<ToTypeArgument<U>>}>`,
-      typeArgs: [extractType(T), extractType(U)] as [
-        PhantomToTypeStr<ToPhantomTypeArgument<T>>,
-        ToTypeStr<ToTypeArgument<U>>,
-      ],
+      get typeName() {
+        return WithSpecialTypes.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypes.$typeName,
+          ...[extractType(T), extractType(U)],
+        ) as `${string}::fixture::WithSpecialTypes<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}, ${ToTypeStr<ToTypeArgument<U>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T), extractType(U)] as [
+          PhantomToTypeStr<ToPhantomTypeArgument<T>>,
+          ToTypeStr<ToTypeArgument<U>>,
+        ]
+      },
       isPhantom: WithSpecialTypes.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => WithSpecialTypes.fromFields([T, U], fields),
@@ -1967,9 +2005,11 @@ export class WithSpecialTypesAsGenerics<
 > implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypesAsGenerics` = `${
-    getTypeOrigin('examples', 'fixture::WithSpecialTypesAsGenerics')
-  }::fixture::WithSpecialTypesAsGenerics` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypesAsGenerics` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithSpecialTypesAsGenerics')
+    }::fixture::WithSpecialTypesAsGenerics` as const
+  }
   static readonly $numTypeParams = 8
   static readonly $isPhantom = [false, false, false, false, false, false, false, false] as const
 
@@ -2076,10 +2116,32 @@ export class WithSpecialTypesAsGenerics<
       toBcs(T7),
     )
     return {
-      typeName: WithSpecialTypesAsGenerics.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypesAsGenerics.$typeName,
-        ...[
+      get typeName() {
+        return WithSpecialTypesAsGenerics.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypesAsGenerics.$typeName,
+          ...[
+            extractType(T0),
+            extractType(T1),
+            extractType(T2),
+            extractType(T3),
+            extractType(T4),
+            extractType(T5),
+            extractType(T6),
+            extractType(T7),
+          ],
+        ) as `${string}::fixture::WithSpecialTypesAsGenerics<${ToTypeStr<
+          ToTypeArgument<T0>
+        >}, ${ToTypeStr<ToTypeArgument<T1>>}, ${ToTypeStr<ToTypeArgument<T2>>}, ${ToTypeStr<
+          ToTypeArgument<T3>
+        >}, ${ToTypeStr<ToTypeArgument<T4>>}, ${ToTypeStr<ToTypeArgument<T5>>}, ${ToTypeStr<
+          ToTypeArgument<T6>
+        >}, ${ToTypeStr<ToTypeArgument<T7>>}>`
+      },
+      get typeArgs() {
+        return [
           extractType(T0),
           extractType(T1),
           extractType(T2),
@@ -2088,33 +2150,17 @@ export class WithSpecialTypesAsGenerics<
           extractType(T5),
           extractType(T6),
           extractType(T7),
-        ],
-      ) as `${string}::fixture::WithSpecialTypesAsGenerics<${ToTypeStr<
-        ToTypeArgument<T0>
-      >}, ${ToTypeStr<ToTypeArgument<T1>>}, ${ToTypeStr<ToTypeArgument<T2>>}, ${ToTypeStr<
-        ToTypeArgument<T3>
-      >}, ${ToTypeStr<ToTypeArgument<T4>>}, ${ToTypeStr<ToTypeArgument<T5>>}, ${ToTypeStr<
-        ToTypeArgument<T6>
-      >}, ${ToTypeStr<ToTypeArgument<T7>>}>`,
-      typeArgs: [
-        extractType(T0),
-        extractType(T1),
-        extractType(T2),
-        extractType(T3),
-        extractType(T4),
-        extractType(T5),
-        extractType(T6),
-        extractType(T7),
-      ] as [
-        ToTypeStr<ToTypeArgument<T0>>,
-        ToTypeStr<ToTypeArgument<T1>>,
-        ToTypeStr<ToTypeArgument<T2>>,
-        ToTypeStr<ToTypeArgument<T3>>,
-        ToTypeStr<ToTypeArgument<T4>>,
-        ToTypeStr<ToTypeArgument<T5>>,
-        ToTypeStr<ToTypeArgument<T6>>,
-        ToTypeStr<ToTypeArgument<T7>>,
-      ],
+        ] as [
+          ToTypeStr<ToTypeArgument<T0>>,
+          ToTypeStr<ToTypeArgument<T1>>,
+          ToTypeStr<ToTypeArgument<T2>>,
+          ToTypeStr<ToTypeArgument<T3>>,
+          ToTypeStr<ToTypeArgument<T4>>,
+          ToTypeStr<ToTypeArgument<T5>>,
+          ToTypeStr<ToTypeArgument<T6>>,
+          ToTypeStr<ToTypeArgument<T7>>,
+        ]
+      },
       isPhantom: WithSpecialTypesAsGenerics.$isPhantom,
       reifiedTypeArgs: [T0, T1, T2, T3, T4, T5, T6, T7],
       fromFields: (fields: Record<string, any>) =>
@@ -2652,9 +2698,11 @@ export type WithSpecialTypesInVectorsJSON<T extends TypeArgument> = {
 export class WithSpecialTypesInVectors<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypesInVectors` = `${
-    getTypeOrigin('examples', 'fixture::WithSpecialTypesInVectors')
-  }::fixture::WithSpecialTypesInVectors` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypesInVectors` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithSpecialTypesInVectors')
+    }::fixture::WithSpecialTypesInVectors` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -2694,12 +2742,18 @@ export class WithSpecialTypesInVectors<T extends TypeArgument> implements Struct
   ): WithSpecialTypesInVectorsReified<ToTypeArgument<T>> {
     const reifiedBcs = WithSpecialTypesInVectors.bcs(toBcs(T))
     return {
-      typeName: WithSpecialTypesInVectors.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypesInVectors.$typeName,
-        ...[extractType(T)],
-      ) as `${string}::fixture::WithSpecialTypesInVectors<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return WithSpecialTypesInVectors.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypesInVectors.$typeName,
+          ...[extractType(T)],
+        ) as `${string}::fixture::WithSpecialTypesInVectors<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: WithSpecialTypesInVectors.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => WithSpecialTypesInVectors.fromFields(T, fields),

--- a/ts/examples/gen/examples/other-module/structs.ts
+++ b/ts/examples/gen/examples/other-module/structs.ts
@@ -53,9 +53,11 @@ export type StructFromOtherModuleJSON = {
 export class StructFromOtherModule implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::other_module::StructFromOtherModule` = `${
-    getTypeOrigin('examples', 'other_module::StructFromOtherModule')
-  }::other_module::StructFromOtherModule` as const
+  static get $typeName(): `${string}::other_module::StructFromOtherModule` {
+    return `${
+      getTypeOrigin('examples', 'other_module::StructFromOtherModule')
+    }::other_module::StructFromOtherModule` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -79,11 +81,15 @@ export class StructFromOtherModule implements StructClass {
   static reified(): StructFromOtherModuleReified {
     const reifiedBcs = StructFromOtherModule.bcs
     return {
-      typeName: StructFromOtherModule.$typeName,
-      fullTypeName: composeSuiType(
-        StructFromOtherModule.$typeName,
-        ...[],
-      ) as `${string}::other_module::StructFromOtherModule`,
+      get typeName() {
+        return StructFromOtherModule.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          StructFromOtherModule.$typeName,
+          ...[],
+        ) as `${string}::other_module::StructFromOtherModule`
+      },
       typeArgs: [] as [],
       isPhantom: StructFromOtherModule.$isPhantom,
       reifiedTypeArgs: [],
@@ -246,9 +252,11 @@ export type AddedInAnUpgradeJSON = {
 export class AddedInAnUpgrade implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::other_module::AddedInAnUpgrade` = `${
-    getTypeOrigin('examples', 'other_module::AddedInAnUpgrade')
-  }::other_module::AddedInAnUpgrade` as const
+  static get $typeName(): `${string}::other_module::AddedInAnUpgrade` {
+    return `${
+      getTypeOrigin('examples', 'other_module::AddedInAnUpgrade')
+    }::other_module::AddedInAnUpgrade` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -272,11 +280,15 @@ export class AddedInAnUpgrade implements StructClass {
   static reified(): AddedInAnUpgradeReified {
     const reifiedBcs = AddedInAnUpgrade.bcs
     return {
-      typeName: AddedInAnUpgrade.$typeName,
-      fullTypeName: composeSuiType(
-        AddedInAnUpgrade.$typeName,
-        ...[],
-      ) as `${string}::other_module::AddedInAnUpgrade`,
+      get typeName() {
+        return AddedInAnUpgrade.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AddedInAnUpgrade.$typeName,
+          ...[],
+        ) as `${string}::other_module::AddedInAnUpgrade`
+      },
       typeArgs: [] as [],
       isPhantom: AddedInAnUpgrade.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/std/ascii/structs.ts
+++ b/ts/examples/gen/std/ascii/structs.ts
@@ -85,11 +85,15 @@ export class String implements StructClass {
   static reified(): StringReified {
     const reifiedBcs = String.bcs
     return {
-      typeName: String.$typeName,
-      fullTypeName: composeSuiType(
-        String.$typeName,
-        ...[],
-      ) as `0x1::ascii::String`,
+      get typeName() {
+        return String.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          String.$typeName,
+          ...[],
+        ) as `0x1::ascii::String`
+      },
       typeArgs: [] as [],
       isPhantom: String.$isPhantom,
       reifiedTypeArgs: [],
@@ -268,11 +272,15 @@ export class Char implements StructClass {
   static reified(): CharReified {
     const reifiedBcs = Char.bcs
     return {
-      typeName: Char.$typeName,
-      fullTypeName: composeSuiType(
-        Char.$typeName,
-        ...[],
-      ) as `0x1::ascii::Char`,
+      get typeName() {
+        return Char.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Char.$typeName,
+          ...[],
+        ) as `0x1::ascii::Char`
+      },
       typeArgs: [] as [],
       isPhantom: Char.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/std/bit-vector/structs.ts
+++ b/ts/examples/gen/std/bit-vector/structs.ts
@@ -77,11 +77,15 @@ export class BitVector implements StructClass {
   static reified(): BitVectorReified {
     const reifiedBcs = BitVector.bcs
     return {
-      typeName: BitVector.$typeName,
-      fullTypeName: composeSuiType(
-        BitVector.$typeName,
-        ...[],
-      ) as `0x1::bit_vector::BitVector`,
+      get typeName() {
+        return BitVector.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          BitVector.$typeName,
+          ...[],
+        ) as `0x1::bit_vector::BitVector`
+      },
       typeArgs: [] as [],
       isPhantom: BitVector.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/std/fixed-point32/structs.ts
+++ b/ts/examples/gen/std/fixed-point32/structs.ts
@@ -87,11 +87,15 @@ export class FixedPoint32 implements StructClass {
   static reified(): FixedPoint32Reified {
     const reifiedBcs = FixedPoint32.bcs
     return {
-      typeName: FixedPoint32.$typeName,
-      fullTypeName: composeSuiType(
-        FixedPoint32.$typeName,
-        ...[],
-      ) as `0x1::fixed_point32::FixedPoint32`,
+      get typeName() {
+        return FixedPoint32.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          FixedPoint32.$typeName,
+          ...[],
+        ) as `0x1::fixed_point32::FixedPoint32`
+      },
       typeArgs: [] as [],
       isPhantom: FixedPoint32.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/std/internal/structs.ts
+++ b/ts/examples/gen/std/internal/structs.ts
@@ -112,12 +112,18 @@ export class Permit<T extends PhantomTypeArgument> implements StructClass {
   ): PermitReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Permit.bcs
     return {
-      typeName: Permit.$typeName,
-      fullTypeName: composeSuiType(
-        Permit.$typeName,
-        ...[extractType(T)],
-      ) as `0x1::internal::Permit<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Permit.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Permit.$typeName,
+          ...[extractType(T)],
+        ) as `0x1::internal::Permit<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Permit.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Permit.fromFields(T, fields),

--- a/ts/examples/gen/std/option/structs.ts
+++ b/ts/examples/gen/std/option/structs.ts
@@ -93,12 +93,18 @@ export class Option<Element extends TypeArgument> implements StructClass {
   ): OptionReified<ToTypeArgument<Element>> {
     const reifiedBcs = Option.bcs(toBcs(Element))
     return {
-      typeName: Option.$typeName,
-      fullTypeName: composeSuiType(
-        Option.$typeName,
-        ...[extractType(Element)],
-      ) as `0x1::option::Option<${ToTypeStr<ToTypeArgument<Element>>}>`,
-      typeArgs: [extractType(Element)] as [ToTypeStr<ToTypeArgument<Element>>],
+      get typeName() {
+        return Option.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Option.$typeName,
+          ...[extractType(Element)],
+        ) as `0x1::option::Option<${ToTypeStr<ToTypeArgument<Element>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Element)] as [ToTypeStr<ToTypeArgument<Element>>]
+      },
       isPhantom: Option.$isPhantom,
       reifiedTypeArgs: [Element],
       fromFields: (fields: Record<string, any>) => Option.fromFields(Element, fields),

--- a/ts/examples/gen/std/string/structs.ts
+++ b/ts/examples/gen/std/string/structs.ts
@@ -82,11 +82,15 @@ export class String implements StructClass {
   static reified(): StringReified {
     const reifiedBcs = String.bcs
     return {
-      typeName: String.$typeName,
-      fullTypeName: composeSuiType(
-        String.$typeName,
-        ...[],
-      ) as `0x1::string::String`,
+      get typeName() {
+        return String.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          String.$typeName,
+          ...[],
+        ) as `0x1::string::String`
+      },
       typeArgs: [] as [],
       isPhantom: String.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/std/type-name/structs.ts
+++ b/ts/examples/gen/std/type-name/structs.ts
@@ -91,11 +91,15 @@ export class TypeName implements StructClass {
   static reified(): TypeNameReified {
     const reifiedBcs = TypeName.bcs
     return {
-      typeName: TypeName.$typeName,
-      fullTypeName: composeSuiType(
-        TypeName.$typeName,
-        ...[],
-      ) as `0x1::type_name::TypeName`,
+      get typeName() {
+        return TypeName.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TypeName.$typeName,
+          ...[],
+        ) as `0x1::type_name::TypeName`
+      },
       typeArgs: [] as [],
       isPhantom: TypeName.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/std/uq32-32/structs.ts
+++ b/ts/examples/gen/std/uq32-32/structs.ts
@@ -85,11 +85,15 @@ export class UQ32_32 implements StructClass {
   static reified(): UQ32_32Reified {
     const reifiedBcs = UQ32_32.bcs
     return {
-      typeName: UQ32_32.$typeName,
-      fullTypeName: composeSuiType(
-        UQ32_32.$typeName,
-        ...[],
-      ) as `0x1::uq32_32::UQ32_32`,
+      get typeName() {
+        return UQ32_32.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UQ32_32.$typeName,
+          ...[],
+        ) as `0x1::uq32_32::UQ32_32`
+      },
       typeArgs: [] as [],
       isPhantom: UQ32_32.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/std/uq64-64/structs.ts
+++ b/ts/examples/gen/std/uq64-64/structs.ts
@@ -85,11 +85,15 @@ export class UQ64_64 implements StructClass {
   static reified(): UQ64_64Reified {
     const reifiedBcs = UQ64_64.bcs
     return {
-      typeName: UQ64_64.$typeName,
-      fullTypeName: composeSuiType(
-        UQ64_64.$typeName,
-        ...[],
-      ) as `0x1::uq64_64::UQ64_64`,
+      get typeName() {
+        return UQ64_64.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UQ64_64.$typeName,
+          ...[],
+        ) as `0x1::uq64_64::UQ64_64`
+      },
       typeArgs: [] as [],
       isPhantom: UQ64_64.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/accumulator-metadata/structs.ts
+++ b/ts/examples/gen/sui/accumulator-metadata/structs.ts
@@ -91,11 +91,15 @@ export class OwnerKey implements StructClass {
   static reified(): OwnerKeyReified {
     const reifiedBcs = OwnerKey.bcs
     return {
-      typeName: OwnerKey.$typeName,
-      fullTypeName: composeSuiType(
-        OwnerKey.$typeName,
-        ...[],
-      ) as `0x2::accumulator_metadata::OwnerKey`,
+      get typeName() {
+        return OwnerKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          OwnerKey.$typeName,
+          ...[],
+        ) as `0x2::accumulator_metadata::OwnerKey`
+      },
       typeArgs: [] as [],
       isPhantom: OwnerKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -287,11 +291,15 @@ export class Owner implements StructClass {
   static reified(): OwnerReified {
     const reifiedBcs = Owner.bcs
     return {
-      typeName: Owner.$typeName,
-      fullTypeName: composeSuiType(
-        Owner.$typeName,
-        ...[],
-      ) as `0x2::accumulator_metadata::Owner`,
+      get typeName() {
+        return Owner.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Owner.$typeName,
+          ...[],
+        ) as `0x2::accumulator_metadata::Owner`
+      },
       typeArgs: [] as [],
       isPhantom: Owner.$isPhantom,
       reifiedTypeArgs: [],
@@ -483,12 +491,18 @@ export class MetadataKey<T extends PhantomTypeArgument> implements StructClass {
   ): MetadataKeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = MetadataKey.bcs
     return {
-      typeName: MetadataKey.$typeName,
-      fullTypeName: composeSuiType(
-        MetadataKey.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::accumulator_metadata::MetadataKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return MetadataKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          MetadataKey.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::accumulator_metadata::MetadataKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: MetadataKey.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => MetadataKey.fromFields(T, fields),
@@ -736,12 +750,18 @@ export class Metadata<T extends PhantomTypeArgument> implements StructClass {
   ): MetadataReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Metadata.bcs
     return {
-      typeName: Metadata.$typeName,
-      fullTypeName: composeSuiType(
-        Metadata.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::accumulator_metadata::Metadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Metadata.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Metadata.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::accumulator_metadata::Metadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Metadata.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Metadata.fromFields(T, fields),

--- a/ts/examples/gen/sui/accumulator-settlement/structs.ts
+++ b/ts/examples/gen/sui/accumulator-settlement/structs.ts
@@ -88,11 +88,15 @@ export class EventStreamHead implements StructClass {
   static reified(): EventStreamHeadReified {
     const reifiedBcs = EventStreamHead.bcs
     return {
-      typeName: EventStreamHead.$typeName,
-      fullTypeName: composeSuiType(
-        EventStreamHead.$typeName,
-        ...[],
-      ) as `0x2::accumulator_settlement::EventStreamHead`,
+      get typeName() {
+        return EventStreamHead.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          EventStreamHead.$typeName,
+          ...[],
+        ) as `0x2::accumulator_settlement::EventStreamHead`
+      },
       typeArgs: [] as [],
       isPhantom: EventStreamHead.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/accumulator/structs.ts
+++ b/ts/examples/gen/sui/accumulator/structs.ts
@@ -79,11 +79,15 @@ export class AccumulatorRoot implements StructClass {
   static reified(): AccumulatorRootReified {
     const reifiedBcs = AccumulatorRoot.bcs
     return {
-      typeName: AccumulatorRoot.$typeName,
-      fullTypeName: composeSuiType(
-        AccumulatorRoot.$typeName,
-        ...[],
-      ) as `0x2::accumulator::AccumulatorRoot`,
+      get typeName() {
+        return AccumulatorRoot.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AccumulatorRoot.$typeName,
+          ...[],
+        ) as `0x2::accumulator::AccumulatorRoot`
+      },
       typeArgs: [] as [],
       isPhantom: AccumulatorRoot.$isPhantom,
       reifiedTypeArgs: [],
@@ -268,11 +272,15 @@ export class U128 implements StructClass {
   static reified(): U128Reified {
     const reifiedBcs = U128.bcs
     return {
-      typeName: U128.$typeName,
-      fullTypeName: composeSuiType(
-        U128.$typeName,
-        ...[],
-      ) as `0x2::accumulator::U128`,
+      get typeName() {
+        return U128.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          U128.$typeName,
+          ...[],
+        ) as `0x2::accumulator::U128`
+      },
       typeArgs: [] as [],
       isPhantom: U128.$isPhantom,
       reifiedTypeArgs: [],
@@ -456,12 +464,18 @@ export class Key<T extends PhantomTypeArgument> implements StructClass {
   ): KeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Key.bcs
     return {
-      typeName: Key.$typeName,
-      fullTypeName: composeSuiType(
-        Key.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::accumulator::Key<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Key.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Key.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::accumulator::Key<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Key.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Key.fromFields(T, fields),

--- a/ts/examples/gen/sui/authenticator-state/structs.ts
+++ b/ts/examples/gen/sui/authenticator-state/structs.ts
@@ -85,11 +85,15 @@ export class AuthenticatorState implements StructClass {
   static reified(): AuthenticatorStateReified {
     const reifiedBcs = AuthenticatorState.bcs
     return {
-      typeName: AuthenticatorState.$typeName,
-      fullTypeName: composeSuiType(
-        AuthenticatorState.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::AuthenticatorState`,
+      get typeName() {
+        return AuthenticatorState.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AuthenticatorState.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::AuthenticatorState`
+      },
       typeArgs: [] as [],
       isPhantom: AuthenticatorState.$isPhantom,
       reifiedTypeArgs: [],
@@ -283,11 +287,15 @@ export class AuthenticatorStateInner implements StructClass {
   static reified(): AuthenticatorStateInnerReified {
     const reifiedBcs = AuthenticatorStateInner.bcs
     return {
-      typeName: AuthenticatorStateInner.$typeName,
-      fullTypeName: composeSuiType(
-        AuthenticatorStateInner.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::AuthenticatorStateInner`,
+      get typeName() {
+        return AuthenticatorStateInner.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AuthenticatorStateInner.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::AuthenticatorStateInner`
+      },
       typeArgs: [] as [],
       isPhantom: AuthenticatorStateInner.$isPhantom,
       reifiedTypeArgs: [],
@@ -490,11 +498,15 @@ export class JWK implements StructClass {
   static reified(): JWKReified {
     const reifiedBcs = JWK.bcs
     return {
-      typeName: JWK.$typeName,
-      fullTypeName: composeSuiType(
-        JWK.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::JWK`,
+      get typeName() {
+        return JWK.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          JWK.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::JWK`
+      },
       typeArgs: [] as [],
       isPhantom: JWK.$isPhantom,
       reifiedTypeArgs: [],
@@ -693,11 +705,15 @@ export class JwkId implements StructClass {
   static reified(): JwkIdReified {
     const reifiedBcs = JwkId.bcs
     return {
-      typeName: JwkId.$typeName,
-      fullTypeName: composeSuiType(
-        JwkId.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::JwkId`,
+      get typeName() {
+        return JwkId.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          JwkId.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::JwkId`
+      },
       typeArgs: [] as [],
       isPhantom: JwkId.$isPhantom,
       reifiedTypeArgs: [],
@@ -889,11 +905,15 @@ export class ActiveJwk implements StructClass {
   static reified(): ActiveJwkReified {
     const reifiedBcs = ActiveJwk.bcs
     return {
-      typeName: ActiveJwk.$typeName,
-      fullTypeName: composeSuiType(
-        ActiveJwk.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::ActiveJwk`,
+      get typeName() {
+        return ActiveJwk.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ActiveJwk.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::ActiveJwk`
+      },
       typeArgs: [] as [],
       isPhantom: ActiveJwk.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/bag/structs.ts
+++ b/ts/examples/gen/sui/bag/structs.ts
@@ -102,11 +102,15 @@ export class Bag implements StructClass {
   static reified(): BagReified {
     const reifiedBcs = Bag.bcs
     return {
-      typeName: Bag.$typeName,
-      fullTypeName: composeSuiType(
-        Bag.$typeName,
-        ...[],
-      ) as `0x2::bag::Bag`,
+      get typeName() {
+        return Bag.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Bag.$typeName,
+          ...[],
+        ) as `0x2::bag::Bag`
+      },
       typeArgs: [] as [],
       isPhantom: Bag.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/balance/structs.ts
+++ b/ts/examples/gen/sui/balance/structs.ts
@@ -89,12 +89,18 @@ export class Supply<T extends PhantomTypeArgument> implements StructClass {
   ): SupplyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Supply.bcs
     return {
-      typeName: Supply.$typeName,
-      fullTypeName: composeSuiType(
-        Supply.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::balance::Supply<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Supply.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Supply.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::balance::Supply<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Supply.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Supply.fromFields(T, fields),
@@ -342,12 +348,18 @@ export class Balance<T extends PhantomTypeArgument> implements StructClass {
   ): BalanceReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Balance.bcs
     return {
-      typeName: Balance.$typeName,
-      fullTypeName: composeSuiType(
-        Balance.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::balance::Balance<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Balance.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Balance.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::balance::Balance<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Balance.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Balance.fromFields(T, fields),

--- a/ts/examples/gen/sui/bcs/structs.ts
+++ b/ts/examples/gen/sui/bcs/structs.ts
@@ -112,11 +112,15 @@ export class BCS implements StructClass {
   static reified(): BCSReified {
     const reifiedBcs = BCS.bcs
     return {
-      typeName: BCS.$typeName,
-      fullTypeName: composeSuiType(
-        BCS.$typeName,
-        ...[],
-      ) as `0x2::bcs::BCS`,
+      get typeName() {
+        return BCS.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          BCS.$typeName,
+          ...[],
+        ) as `0x2::bcs::BCS`
+      },
       typeArgs: [] as [],
       isPhantom: BCS.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/bls12381/structs.ts
+++ b/ts/examples/gen/sui/bls12381/structs.ts
@@ -72,11 +72,15 @@ export class Scalar implements StructClass {
   static reified(): ScalarReified {
     const reifiedBcs = Scalar.bcs
     return {
-      typeName: Scalar.$typeName,
-      fullTypeName: composeSuiType(
-        Scalar.$typeName,
-        ...[],
-      ) as `0x2::bls12381::Scalar`,
+      get typeName() {
+        return Scalar.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Scalar.$typeName,
+          ...[],
+        ) as `0x2::bls12381::Scalar`
+      },
       typeArgs: [] as [],
       isPhantom: Scalar.$isPhantom,
       reifiedTypeArgs: [],
@@ -254,11 +258,15 @@ export class G1 implements StructClass {
   static reified(): G1Reified {
     const reifiedBcs = G1.bcs
     return {
-      typeName: G1.$typeName,
-      fullTypeName: composeSuiType(
-        G1.$typeName,
-        ...[],
-      ) as `0x2::bls12381::G1`,
+      get typeName() {
+        return G1.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          G1.$typeName,
+          ...[],
+        ) as `0x2::bls12381::G1`
+      },
       typeArgs: [] as [],
       isPhantom: G1.$isPhantom,
       reifiedTypeArgs: [],
@@ -436,11 +444,15 @@ export class G2 implements StructClass {
   static reified(): G2Reified {
     const reifiedBcs = G2.bcs
     return {
-      typeName: G2.$typeName,
-      fullTypeName: composeSuiType(
-        G2.$typeName,
-        ...[],
-      ) as `0x2::bls12381::G2`,
+      get typeName() {
+        return G2.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          G2.$typeName,
+          ...[],
+        ) as `0x2::bls12381::G2`
+      },
       typeArgs: [] as [],
       isPhantom: G2.$isPhantom,
       reifiedTypeArgs: [],
@@ -618,11 +630,15 @@ export class GT implements StructClass {
   static reified(): GTReified {
     const reifiedBcs = GT.bcs
     return {
-      typeName: GT.$typeName,
-      fullTypeName: composeSuiType(
-        GT.$typeName,
-        ...[],
-      ) as `0x2::bls12381::GT`,
+      get typeName() {
+        return GT.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          GT.$typeName,
+          ...[],
+        ) as `0x2::bls12381::GT`
+      },
       typeArgs: [] as [],
       isPhantom: GT.$isPhantom,
       reifiedTypeArgs: [],
@@ -801,11 +817,15 @@ export class UncompressedG1 implements StructClass {
   static reified(): UncompressedG1Reified {
     const reifiedBcs = UncompressedG1.bcs
     return {
-      typeName: UncompressedG1.$typeName,
-      fullTypeName: composeSuiType(
-        UncompressedG1.$typeName,
-        ...[],
-      ) as `0x2::bls12381::UncompressedG1`,
+      get typeName() {
+        return UncompressedG1.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UncompressedG1.$typeName,
+          ...[],
+        ) as `0x2::bls12381::UncompressedG1`
+      },
       typeArgs: [] as [],
       isPhantom: UncompressedG1.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/borrow/structs.ts
+++ b/ts/examples/gen/sui/borrow/structs.ts
@@ -95,12 +95,18 @@ export class Referent<T extends TypeArgument> implements StructClass {
   ): ReferentReified<ToTypeArgument<T>> {
     const reifiedBcs = Referent.bcs(toBcs(T))
     return {
-      typeName: Referent.$typeName,
-      fullTypeName: composeSuiType(
-        Referent.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::borrow::Referent<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return Referent.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Referent.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::borrow::Referent<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: Referent.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Referent.fromFields(T, fields),
@@ -357,11 +363,15 @@ export class Borrow implements StructClass {
   static reified(): BorrowReified {
     const reifiedBcs = Borrow.bcs
     return {
-      typeName: Borrow.$typeName,
-      fullTypeName: composeSuiType(
-        Borrow.$typeName,
-        ...[],
-      ) as `0x2::borrow::Borrow`,
+      get typeName() {
+        return Borrow.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Borrow.$typeName,
+          ...[],
+        ) as `0x2::borrow::Borrow`
+      },
       typeArgs: [] as [],
       isPhantom: Borrow.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/clock/structs.ts
+++ b/ts/examples/gen/sui/clock/structs.ts
@@ -102,11 +102,15 @@ export class Clock implements StructClass {
   static reified(): ClockReified {
     const reifiedBcs = Clock.bcs
     return {
-      typeName: Clock.$typeName,
-      fullTypeName: composeSuiType(
-        Clock.$typeName,
-        ...[],
-      ) as `0x2::clock::Clock`,
+      get typeName() {
+        return Clock.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Clock.$typeName,
+          ...[],
+        ) as `0x2::clock::Clock`
+      },
       typeArgs: [] as [],
       isPhantom: Clock.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/coin-registry/structs.ts
+++ b/ts/examples/gen/sui/coin-registry/structs.ts
@@ -101,11 +101,15 @@ export class CoinRegistry implements StructClass {
   static reified(): CoinRegistryReified {
     const reifiedBcs = CoinRegistry.bcs
     return {
-      typeName: CoinRegistry.$typeName,
-      fullTypeName: composeSuiType(
-        CoinRegistry.$typeName,
-        ...[],
-      ) as `0x2::coin_registry::CoinRegistry`,
+      get typeName() {
+        return CoinRegistry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CoinRegistry.$typeName,
+          ...[],
+        ) as `0x2::coin_registry::CoinRegistry`
+      },
       typeArgs: [] as [],
       isPhantom: CoinRegistry.$isPhantom,
       reifiedTypeArgs: [],
@@ -293,11 +297,15 @@ export class ExtraField implements StructClass {
   static reified(): ExtraFieldReified {
     const reifiedBcs = ExtraField.bcs
     return {
-      typeName: ExtraField.$typeName,
-      fullTypeName: composeSuiType(
-        ExtraField.$typeName,
-        ...[],
-      ) as `0x2::coin_registry::ExtraField`,
+      get typeName() {
+        return ExtraField.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ExtraField.$typeName,
+          ...[],
+        ) as `0x2::coin_registry::ExtraField`
+      },
       typeArgs: [] as [],
       isPhantom: ExtraField.$isPhantom,
       reifiedTypeArgs: [],
@@ -487,12 +495,18 @@ export class CurrencyKey<T extends PhantomTypeArgument> implements StructClass {
   ): CurrencyKeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = CurrencyKey.bcs
     return {
-      typeName: CurrencyKey.$typeName,
-      fullTypeName: composeSuiType(
-        CurrencyKey.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::CurrencyKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return CurrencyKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CurrencyKey.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::CurrencyKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: CurrencyKey.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => CurrencyKey.fromFields(T, fields),
@@ -736,11 +750,15 @@ export class LegacyMetadataKey implements StructClass {
   static reified(): LegacyMetadataKeyReified {
     const reifiedBcs = LegacyMetadataKey.bcs
     return {
-      typeName: LegacyMetadataKey.$typeName,
-      fullTypeName: composeSuiType(
-        LegacyMetadataKey.$typeName,
-        ...[],
-      ) as `0x2::coin_registry::LegacyMetadataKey`,
+      get typeName() {
+        return LegacyMetadataKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          LegacyMetadataKey.$typeName,
+          ...[],
+        ) as `0x2::coin_registry::LegacyMetadataKey`
+      },
       typeArgs: [] as [],
       isPhantom: LegacyMetadataKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -929,12 +947,18 @@ export class MetadataCap<T extends PhantomTypeArgument> implements StructClass {
   ): MetadataCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = MetadataCap.bcs
     return {
-      typeName: MetadataCap.$typeName,
-      fullTypeName: composeSuiType(
-        MetadataCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::MetadataCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return MetadataCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          MetadataCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::MetadataCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: MetadataCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => MetadataCap.fromFields(T, fields),
@@ -1179,12 +1203,18 @@ export class Borrow<T extends PhantomTypeArgument> implements StructClass {
   ): BorrowReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Borrow.bcs
     return {
-      typeName: Borrow.$typeName,
-      fullTypeName: composeSuiType(
-        Borrow.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::Borrow<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Borrow.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Borrow.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::Borrow<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Borrow.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Borrow.fromFields(T, fields),
@@ -1501,12 +1531,18 @@ export class Currency<T extends PhantomTypeArgument> implements StructClass {
   ): CurrencyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Currency.bcs
     return {
-      typeName: Currency.$typeName,
-      fullTypeName: composeSuiType(
-        Currency.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::Currency<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Currency.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Currency.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::Currency<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Currency.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Currency.fromFields(T, fields),
@@ -1842,12 +1878,20 @@ export class CurrencyInitializer<T extends PhantomTypeArgument> implements Struc
   ): CurrencyInitializerReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = CurrencyInitializer.bcs
     return {
-      typeName: CurrencyInitializer.$typeName,
-      fullTypeName: composeSuiType(
-        CurrencyInitializer.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::CurrencyInitializer<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return CurrencyInitializer.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CurrencyInitializer.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::CurrencyInitializer<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: CurrencyInitializer.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => CurrencyInitializer.fromFields(T, fields),
@@ -2105,12 +2149,18 @@ export class SupplyState {
   ): SupplyStateReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = SupplyState.bcs
     return {
-      typeName: SupplyState.$typeName,
-      fullTypeName: composeSuiType(
-        SupplyState.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::SupplyState<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return SupplyState.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          SupplyState.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::SupplyState<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: SupplyState.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => SupplyState.fromFields([T], fields),
@@ -2295,7 +2345,9 @@ export type SupplyStateFixedJSON<T extends PhantomTypeArgument> = {
 export class SupplyStateFixed<T extends PhantomTypeArgument> implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof SupplyState.$typeName = SupplyState.$typeName
+  static get $typeName(): typeof SupplyState.$typeName {
+    return SupplyState.$typeName
+  }
   static readonly $numTypeParams: typeof SupplyState.$numTypeParams = SupplyState.$numTypeParams
   static readonly $isPhantom: typeof SupplyState.$isPhantom = SupplyState.$isPhantom
   static readonly $variantName = 'Fixed' as const
@@ -2356,7 +2408,9 @@ export type SupplyStateBurnOnlyJSON<T extends PhantomTypeArgument> = {
 export class SupplyStateBurnOnly<T extends PhantomTypeArgument> implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof SupplyState.$typeName = SupplyState.$typeName
+  static get $typeName(): typeof SupplyState.$typeName {
+    return SupplyState.$typeName
+  }
   static readonly $numTypeParams: typeof SupplyState.$numTypeParams = SupplyState.$numTypeParams
   static readonly $isPhantom: typeof SupplyState.$isPhantom = SupplyState.$isPhantom
   static readonly $variantName = 'BurnOnly' as const
@@ -2414,7 +2468,9 @@ export type SupplyStateUnknownJSON<T extends PhantomTypeArgument> = {
 export class SupplyStateUnknown<T extends PhantomTypeArgument> implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof SupplyState.$typeName = SupplyState.$typeName
+  static get $typeName(): typeof SupplyState.$typeName {
+    return SupplyState.$typeName
+  }
   static readonly $numTypeParams: typeof SupplyState.$numTypeParams = SupplyState.$numTypeParams
   static readonly $isPhantom: typeof SupplyState.$isPhantom = SupplyState.$isPhantom
   static readonly $variantName = 'Unknown' as const
@@ -2496,10 +2552,12 @@ export class RegulatedState {
   static reified(): RegulatedStateReified {
     const reifiedBcs = RegulatedState.bcs
     return {
-      typeName: RegulatedState.$typeName,
-      fullTypeName: composeSuiType(
-        RegulatedState.$typeName,
-      ) as `0x2::coin_registry::RegulatedState`,
+      get typeName() {
+        return RegulatedState.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(RegulatedState.$typeName) as `0x2::coin_registry::RegulatedState`
+      },
       typeArgs: [] as [],
       isPhantom: RegulatedState.$isPhantom,
       reifiedTypeArgs: [],
@@ -2670,7 +2728,9 @@ export type RegulatedStateRegulatedJSON = {
 export class RegulatedStateRegulated implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof RegulatedState.$typeName = RegulatedState.$typeName
+  static get $typeName(): typeof RegulatedState.$typeName {
+    return RegulatedState.$typeName
+  }
   static readonly $numTypeParams: typeof RegulatedState.$numTypeParams =
     RegulatedState.$numTypeParams
   static readonly $isPhantom: typeof RegulatedState.$isPhantom = RegulatedState.$isPhantom
@@ -2737,7 +2797,9 @@ export type RegulatedStateUnregulatedJSON = {
 export class RegulatedStateUnregulated implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof RegulatedState.$typeName = RegulatedState.$typeName
+  static get $typeName(): typeof RegulatedState.$typeName {
+    return RegulatedState.$typeName
+  }
   static readonly $numTypeParams: typeof RegulatedState.$numTypeParams =
     RegulatedState.$numTypeParams
   static readonly $isPhantom: typeof RegulatedState.$isPhantom = RegulatedState.$isPhantom
@@ -2792,7 +2854,9 @@ export type RegulatedStateUnknownJSON = {
 export class RegulatedStateUnknown implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof RegulatedState.$typeName = RegulatedState.$typeName
+  static get $typeName(): typeof RegulatedState.$typeName {
+    return RegulatedState.$typeName
+  }
   static readonly $numTypeParams: typeof RegulatedState.$numTypeParams =
     RegulatedState.$numTypeParams
   static readonly $isPhantom: typeof RegulatedState.$isPhantom = RegulatedState.$isPhantom
@@ -2873,10 +2937,12 @@ export class MetadataCapState {
   static reified(): MetadataCapStateReified {
     const reifiedBcs = MetadataCapState.bcs
     return {
-      typeName: MetadataCapState.$typeName,
-      fullTypeName: composeSuiType(
-        MetadataCapState.$typeName,
-      ) as `0x2::coin_registry::MetadataCapState`,
+      get typeName() {
+        return MetadataCapState.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(MetadataCapState.$typeName) as `0x2::coin_registry::MetadataCapState`
+      },
       typeArgs: [] as [],
       isPhantom: MetadataCapState.$isPhantom,
       reifiedTypeArgs: [],
@@ -3025,7 +3091,9 @@ export type MetadataCapStateClaimedJSON = {
 export class MetadataCapStateClaimed implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof MetadataCapState.$typeName = MetadataCapState.$typeName
+  static get $typeName(): typeof MetadataCapState.$typeName {
+    return MetadataCapState.$typeName
+  }
   static readonly $numTypeParams: typeof MetadataCapState.$numTypeParams =
     MetadataCapState.$numTypeParams
   static readonly $isPhantom: typeof MetadataCapState.$isPhantom = MetadataCapState.$isPhantom
@@ -3085,7 +3153,9 @@ export type MetadataCapStateUnclaimedJSON = {
 export class MetadataCapStateUnclaimed implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof MetadataCapState.$typeName = MetadataCapState.$typeName
+  static get $typeName(): typeof MetadataCapState.$typeName {
+    return MetadataCapState.$typeName
+  }
   static readonly $numTypeParams: typeof MetadataCapState.$numTypeParams =
     MetadataCapState.$numTypeParams
   static readonly $isPhantom: typeof MetadataCapState.$isPhantom = MetadataCapState.$isPhantom
@@ -3137,7 +3207,9 @@ export type MetadataCapStateDeletedJSON = {
 export class MetadataCapStateDeleted implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof MetadataCapState.$typeName = MetadataCapState.$typeName
+  static get $typeName(): typeof MetadataCapState.$typeName {
+    return MetadataCapState.$typeName
+  }
   static readonly $numTypeParams: typeof MetadataCapState.$numTypeParams =
     MetadataCapState.$numTypeParams
   static readonly $isPhantom: typeof MetadataCapState.$isPhantom = MetadataCapState.$isPhantom

--- a/ts/examples/gen/sui/coin/structs.ts
+++ b/ts/examples/gen/sui/coin/structs.ts
@@ -97,12 +97,18 @@ export class Coin<T extends PhantomTypeArgument> implements StructClass {
   ): CoinReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Coin.bcs
     return {
-      typeName: Coin.$typeName,
-      fullTypeName: composeSuiType(
-        Coin.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::Coin<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Coin.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Coin.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::Coin<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Coin.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Coin.fromFields(T, fields),
@@ -398,12 +404,18 @@ export class CoinMetadata<T extends PhantomTypeArgument> implements StructClass 
   ): CoinMetadataReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = CoinMetadata.bcs
     return {
-      typeName: CoinMetadata.$typeName,
-      fullTypeName: composeSuiType(
-        CoinMetadata.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::CoinMetadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return CoinMetadata.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CoinMetadata.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::CoinMetadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: CoinMetadata.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => CoinMetadata.fromFields(T, fields),
@@ -692,12 +704,18 @@ export class RegulatedCoinMetadata<T extends PhantomTypeArgument> implements Str
   ): RegulatedCoinMetadataReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = RegulatedCoinMetadata.bcs
     return {
-      typeName: RegulatedCoinMetadata.$typeName,
-      fullTypeName: composeSuiType(
-        RegulatedCoinMetadata.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::RegulatedCoinMetadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return RegulatedCoinMetadata.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RegulatedCoinMetadata.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::RegulatedCoinMetadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: RegulatedCoinMetadata.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => RegulatedCoinMetadata.fromFields(T, fields),
@@ -968,12 +986,18 @@ export class TreasuryCap<T extends PhantomTypeArgument> implements StructClass {
   ): TreasuryCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TreasuryCap.bcs
     return {
-      typeName: TreasuryCap.$typeName,
-      fullTypeName: composeSuiType(
-        TreasuryCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::TreasuryCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TreasuryCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TreasuryCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::TreasuryCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TreasuryCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TreasuryCap.fromFields(T, fields),
@@ -1236,12 +1260,18 @@ export class DenyCapV2<T extends PhantomTypeArgument> implements StructClass {
   ): DenyCapV2Reified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = DenyCapV2.bcs
     return {
-      typeName: DenyCapV2.$typeName,
-      fullTypeName: composeSuiType(
-        DenyCapV2.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::DenyCapV2<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return DenyCapV2.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DenyCapV2.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::DenyCapV2<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: DenyCapV2.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => DenyCapV2.fromFields(T, fields),
@@ -1493,12 +1523,18 @@ export class CurrencyCreated<T extends PhantomTypeArgument> implements StructCla
   ): CurrencyCreatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = CurrencyCreated.bcs
     return {
-      typeName: CurrencyCreated.$typeName,
-      fullTypeName: composeSuiType(
-        CurrencyCreated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::CurrencyCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return CurrencyCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CurrencyCreated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::CurrencyCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: CurrencyCreated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => CurrencyCreated.fromFields(T, fields),
@@ -1746,12 +1782,18 @@ export class DenyCap<T extends PhantomTypeArgument> implements StructClass {
   ): DenyCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = DenyCap.bcs
     return {
-      typeName: DenyCap.$typeName,
-      fullTypeName: composeSuiType(
-        DenyCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::DenyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return DenyCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DenyCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::DenyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: DenyCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => DenyCap.fromFields(T, fields),

--- a/ts/examples/gen/sui/config/structs.ts
+++ b/ts/examples/gen/sui/config/structs.ts
@@ -88,12 +88,18 @@ export class Config<WriteCap extends PhantomTypeArgument> implements StructClass
   ): ConfigReified<ToPhantomTypeArgument<WriteCap>> {
     const reifiedBcs = Config.bcs
     return {
-      typeName: Config.$typeName,
-      fullTypeName: composeSuiType(
-        Config.$typeName,
-        ...[extractType(WriteCap)],
-      ) as `0x2::config::Config<${PhantomToTypeStr<ToPhantomTypeArgument<WriteCap>>}>`,
-      typeArgs: [extractType(WriteCap)] as [PhantomToTypeStr<ToPhantomTypeArgument<WriteCap>>],
+      get typeName() {
+        return Config.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Config.$typeName,
+          ...[extractType(WriteCap)],
+        ) as `0x2::config::Config<${PhantomToTypeStr<ToPhantomTypeArgument<WriteCap>>}>`
+      },
+      get typeArgs() {
+        return [extractType(WriteCap)] as [PhantomToTypeStr<ToPhantomTypeArgument<WriteCap>>]
+      },
       isPhantom: Config.$isPhantom,
       reifiedTypeArgs: [WriteCap],
       fromFields: (fields: Record<string, any>) => Config.fromFields(WriteCap, fields),
@@ -340,12 +346,18 @@ export class Setting<Value extends TypeArgument> implements StructClass {
   ): SettingReified<ToTypeArgument<Value>> {
     const reifiedBcs = Setting.bcs(toBcs(Value))
     return {
-      typeName: Setting.$typeName,
-      fullTypeName: composeSuiType(
-        Setting.$typeName,
-        ...[extractType(Value)],
-      ) as `0x2::config::Setting<${ToTypeStr<ToTypeArgument<Value>>}>`,
-      typeArgs: [extractType(Value)] as [ToTypeStr<ToTypeArgument<Value>>],
+      get typeName() {
+        return Setting.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Setting.$typeName,
+          ...[extractType(Value)],
+        ) as `0x2::config::Setting<${ToTypeStr<ToTypeArgument<Value>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Value)] as [ToTypeStr<ToTypeArgument<Value>>]
+      },
       isPhantom: Setting.$isPhantom,
       reifiedTypeArgs: [Value],
       fromFields: (fields: Record<string, any>) => Setting.fromFields(Value, fields),
@@ -608,12 +620,18 @@ export class SettingData<Value extends TypeArgument> implements StructClass {
   ): SettingDataReified<ToTypeArgument<Value>> {
     const reifiedBcs = SettingData.bcs(toBcs(Value))
     return {
-      typeName: SettingData.$typeName,
-      fullTypeName: composeSuiType(
-        SettingData.$typeName,
-        ...[extractType(Value)],
-      ) as `0x2::config::SettingData<${ToTypeStr<ToTypeArgument<Value>>}>`,
-      typeArgs: [extractType(Value)] as [ToTypeStr<ToTypeArgument<Value>>],
+      get typeName() {
+        return SettingData.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          SettingData.$typeName,
+          ...[extractType(Value)],
+        ) as `0x2::config::SettingData<${ToTypeStr<ToTypeArgument<Value>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Value)] as [ToTypeStr<ToTypeArgument<Value>>]
+      },
       isPhantom: SettingData.$isPhantom,
       reifiedTypeArgs: [Value],
       fromFields: (fields: Record<string, any>) => SettingData.fromFields(Value, fields),

--- a/ts/examples/gen/sui/deny-list/structs.ts
+++ b/ts/examples/gen/sui/deny-list/structs.ts
@@ -91,11 +91,15 @@ export class DenyList implements StructClass {
   static reified(): DenyListReified {
     const reifiedBcs = DenyList.bcs
     return {
-      typeName: DenyList.$typeName,
-      fullTypeName: composeSuiType(
-        DenyList.$typeName,
-        ...[],
-      ) as `0x2::deny_list::DenyList`,
+      get typeName() {
+        return DenyList.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DenyList.$typeName,
+          ...[],
+        ) as `0x2::deny_list::DenyList`
+      },
       typeArgs: [] as [],
       isPhantom: DenyList.$isPhantom,
       reifiedTypeArgs: [],
@@ -283,11 +287,15 @@ export class ConfigWriteCap implements StructClass {
   static reified(): ConfigWriteCapReified {
     const reifiedBcs = ConfigWriteCap.bcs
     return {
-      typeName: ConfigWriteCap.$typeName,
-      fullTypeName: composeSuiType(
-        ConfigWriteCap.$typeName,
-        ...[],
-      ) as `0x2::deny_list::ConfigWriteCap`,
+      get typeName() {
+        return ConfigWriteCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ConfigWriteCap.$typeName,
+          ...[],
+        ) as `0x2::deny_list::ConfigWriteCap`
+      },
       typeArgs: [] as [],
       isPhantom: ConfigWriteCap.$isPhantom,
       reifiedTypeArgs: [],
@@ -473,11 +481,15 @@ export class ConfigKey implements StructClass {
   static reified(): ConfigKeyReified {
     const reifiedBcs = ConfigKey.bcs
     return {
-      typeName: ConfigKey.$typeName,
-      fullTypeName: composeSuiType(
-        ConfigKey.$typeName,
-        ...[],
-      ) as `0x2::deny_list::ConfigKey`,
+      get typeName() {
+        return ConfigKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ConfigKey.$typeName,
+          ...[],
+        ) as `0x2::deny_list::ConfigKey`
+      },
       typeArgs: [] as [],
       isPhantom: ConfigKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -661,11 +673,15 @@ export class AddressKey implements StructClass {
   static reified(): AddressKeyReified {
     const reifiedBcs = AddressKey.bcs
     return {
-      typeName: AddressKey.$typeName,
-      fullTypeName: composeSuiType(
-        AddressKey.$typeName,
-        ...[],
-      ) as `0x2::deny_list::AddressKey`,
+      get typeName() {
+        return AddressKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AddressKey.$typeName,
+          ...[],
+        ) as `0x2::deny_list::AddressKey`
+      },
       typeArgs: [] as [],
       isPhantom: AddressKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -848,11 +864,15 @@ export class GlobalPauseKey implements StructClass {
   static reified(): GlobalPauseKeyReified {
     const reifiedBcs = GlobalPauseKey.bcs
     return {
-      typeName: GlobalPauseKey.$typeName,
-      fullTypeName: composeSuiType(
-        GlobalPauseKey.$typeName,
-        ...[],
-      ) as `0x2::deny_list::GlobalPauseKey`,
+      get typeName() {
+        return GlobalPauseKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          GlobalPauseKey.$typeName,
+          ...[],
+        ) as `0x2::deny_list::GlobalPauseKey`
+      },
       typeArgs: [] as [],
       isPhantom: GlobalPauseKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -1039,11 +1059,15 @@ export class PerTypeConfigCreated implements StructClass {
   static reified(): PerTypeConfigCreatedReified {
     const reifiedBcs = PerTypeConfigCreated.bcs
     return {
-      typeName: PerTypeConfigCreated.$typeName,
-      fullTypeName: composeSuiType(
-        PerTypeConfigCreated.$typeName,
-        ...[],
-      ) as `0x2::deny_list::PerTypeConfigCreated`,
+      get typeName() {
+        return PerTypeConfigCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PerTypeConfigCreated.$typeName,
+          ...[],
+        ) as `0x2::deny_list::PerTypeConfigCreated`
+      },
       typeArgs: [] as [],
       isPhantom: PerTypeConfigCreated.$isPhantom,
       reifiedTypeArgs: [],
@@ -1259,11 +1283,15 @@ export class PerTypeList implements StructClass {
   static reified(): PerTypeListReified {
     const reifiedBcs = PerTypeList.bcs
     return {
-      typeName: PerTypeList.$typeName,
-      fullTypeName: composeSuiType(
-        PerTypeList.$typeName,
-        ...[],
-      ) as `0x2::deny_list::PerTypeList`,
+      get typeName() {
+        return PerTypeList.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PerTypeList.$typeName,
+          ...[],
+        ) as `0x2::deny_list::PerTypeList`
+      },
       typeArgs: [] as [],
       isPhantom: PerTypeList.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/derived-object/structs.ts
+++ b/ts/examples/gen/sui/derived-object/structs.ts
@@ -97,11 +97,15 @@ export class Claimed implements StructClass {
   static reified(): ClaimedReified {
     const reifiedBcs = Claimed.bcs
     return {
-      typeName: Claimed.$typeName,
-      fullTypeName: composeSuiType(
-        Claimed.$typeName,
-        ...[],
-      ) as `0x2::derived_object::Claimed`,
+      get typeName() {
+        return Claimed.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Claimed.$typeName,
+          ...[],
+        ) as `0x2::derived_object::Claimed`
+      },
       typeArgs: [] as [],
       isPhantom: Claimed.$isPhantom,
       reifiedTypeArgs: [],
@@ -286,12 +290,18 @@ export class DerivedObjectKey<K extends TypeArgument> implements StructClass {
   ): DerivedObjectKeyReified<ToTypeArgument<K>> {
     const reifiedBcs = DerivedObjectKey.bcs(toBcs(K))
     return {
-      typeName: DerivedObjectKey.$typeName,
-      fullTypeName: composeSuiType(
-        DerivedObjectKey.$typeName,
-        ...[extractType(K)],
-      ) as `0x2::derived_object::DerivedObjectKey<${ToTypeStr<ToTypeArgument<K>>}>`,
-      typeArgs: [extractType(K)] as [ToTypeStr<ToTypeArgument<K>>],
+      get typeName() {
+        return DerivedObjectKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DerivedObjectKey.$typeName,
+          ...[extractType(K)],
+        ) as `0x2::derived_object::DerivedObjectKey<${ToTypeStr<ToTypeArgument<K>>}>`
+      },
+      get typeArgs() {
+        return [extractType(K)] as [ToTypeStr<ToTypeArgument<K>>]
+      },
       isPhantom: DerivedObjectKey.$isPhantom,
       reifiedTypeArgs: [K],
       fromFields: (fields: Record<string, any>) => DerivedObjectKey.fromFields(K, fields),
@@ -525,8 +535,12 @@ export class ClaimedStatus {
   static reified(): ClaimedStatusReified {
     const reifiedBcs = ClaimedStatus.bcs
     return {
-      typeName: ClaimedStatus.$typeName,
-      fullTypeName: composeSuiType(ClaimedStatus.$typeName) as `0x2::derived_object::ClaimedStatus`,
+      get typeName() {
+        return ClaimedStatus.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(ClaimedStatus.$typeName) as `0x2::derived_object::ClaimedStatus`
+      },
       typeArgs: [] as [],
       isPhantom: ClaimedStatus.$isPhantom,
       reifiedTypeArgs: [],
@@ -647,7 +661,9 @@ export type ClaimedStatusReservedJSON = {
 export class ClaimedStatusReserved implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof ClaimedStatus.$typeName = ClaimedStatus.$typeName
+  static get $typeName(): typeof ClaimedStatus.$typeName {
+    return ClaimedStatus.$typeName
+  }
   static readonly $numTypeParams: typeof ClaimedStatus.$numTypeParams = ClaimedStatus.$numTypeParams
   static readonly $isPhantom: typeof ClaimedStatus.$isPhantom = ClaimedStatus.$isPhantom
   static readonly $variantName = 'Reserved' as const

--- a/ts/examples/gen/sui/display/structs.ts
+++ b/ts/examples/gen/sui/display/structs.ts
@@ -135,12 +135,18 @@ export class Display<T extends PhantomTypeArgument> implements StructClass {
   ): DisplayReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Display.bcs
     return {
-      typeName: Display.$typeName,
-      fullTypeName: composeSuiType(
-        Display.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::display::Display<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Display.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Display.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::display::Display<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Display.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Display.fromFields(T, fields),
@@ -409,12 +415,18 @@ export class DisplayCreated<T extends PhantomTypeArgument> implements StructClas
   ): DisplayCreatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = DisplayCreated.bcs
     return {
-      typeName: DisplayCreated.$typeName,
-      fullTypeName: composeSuiType(
-        DisplayCreated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::display::DisplayCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return DisplayCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DisplayCreated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::display::DisplayCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: DisplayCreated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => DisplayCreated.fromFields(T, fields),
@@ -671,12 +683,18 @@ export class VersionUpdated<T extends PhantomTypeArgument> implements StructClas
   ): VersionUpdatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = VersionUpdated.bcs
     return {
-      typeName: VersionUpdated.$typeName,
-      fullTypeName: composeSuiType(
-        VersionUpdated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::display::VersionUpdated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return VersionUpdated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VersionUpdated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::display::VersionUpdated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: VersionUpdated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => VersionUpdated.fromFields(T, fields),

--- a/ts/examples/gen/sui/dynamic-field/structs.ts
+++ b/ts/examples/gen/sui/dynamic-field/structs.ts
@@ -118,17 +118,23 @@ export class Field<Name extends TypeArgument, Value extends TypeArgument> implem
   ): FieldReified<ToTypeArgument<Name>, ToTypeArgument<Value>> {
     const reifiedBcs = Field.bcs(toBcs(Name), toBcs(Value))
     return {
-      typeName: Field.$typeName,
-      fullTypeName: composeSuiType(
-        Field.$typeName,
-        ...[extractType(Name), extractType(Value)],
-      ) as `0x2::dynamic_field::Field<${ToTypeStr<ToTypeArgument<Name>>}, ${ToTypeStr<
-        ToTypeArgument<Value>
-      >}>`,
-      typeArgs: [extractType(Name), extractType(Value)] as [
-        ToTypeStr<ToTypeArgument<Name>>,
-        ToTypeStr<ToTypeArgument<Value>>,
-      ],
+      get typeName() {
+        return Field.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Field.$typeName,
+          ...[extractType(Name), extractType(Value)],
+        ) as `0x2::dynamic_field::Field<${ToTypeStr<ToTypeArgument<Name>>}, ${ToTypeStr<
+          ToTypeArgument<Value>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(Name), extractType(Value)] as [
+          ToTypeStr<ToTypeArgument<Name>>,
+          ToTypeStr<ToTypeArgument<Value>>,
+        ]
+      },
       isPhantom: Field.$isPhantom,
       reifiedTypeArgs: [Name, Value],
       fromFields: (fields: Record<string, any>) => Field.fromFields([Name, Value], fields),

--- a/ts/examples/gen/sui/dynamic-object-field/structs.ts
+++ b/ts/examples/gen/sui/dynamic-object-field/structs.ts
@@ -88,12 +88,18 @@ export class Wrapper<Name extends TypeArgument> implements StructClass {
   ): WrapperReified<ToTypeArgument<Name>> {
     const reifiedBcs = Wrapper.bcs(toBcs(Name))
     return {
-      typeName: Wrapper.$typeName,
-      fullTypeName: composeSuiType(
-        Wrapper.$typeName,
-        ...[extractType(Name)],
-      ) as `0x2::dynamic_object_field::Wrapper<${ToTypeStr<ToTypeArgument<Name>>}>`,
-      typeArgs: [extractType(Name)] as [ToTypeStr<ToTypeArgument<Name>>],
+      get typeName() {
+        return Wrapper.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Wrapper.$typeName,
+          ...[extractType(Name)],
+        ) as `0x2::dynamic_object_field::Wrapper<${ToTypeStr<ToTypeArgument<Name>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Name)] as [ToTypeStr<ToTypeArgument<Name>>]
+      },
       isPhantom: Wrapper.$isPhantom,
       reifiedTypeArgs: [Name],
       fromFields: (fields: Record<string, any>) => Wrapper.fromFields(Name, fields),

--- a/ts/examples/gen/sui/funds-accumulator/structs.ts
+++ b/ts/examples/gen/sui/funds-accumulator/structs.ts
@@ -104,12 +104,18 @@ export class Withdrawal<T extends PhantomTypeArgument> implements StructClass {
   ): WithdrawalReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Withdrawal.bcs
     return {
-      typeName: Withdrawal.$typeName,
-      fullTypeName: composeSuiType(
-        Withdrawal.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::funds_accumulator::Withdrawal<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Withdrawal.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Withdrawal.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::funds_accumulator::Withdrawal<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Withdrawal.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Withdrawal.fromFields(T, fields),

--- a/ts/examples/gen/sui/groth16/structs.ts
+++ b/ts/examples/gen/sui/groth16/structs.ts
@@ -77,11 +77,15 @@ export class Curve implements StructClass {
   static reified(): CurveReified {
     const reifiedBcs = Curve.bcs
     return {
-      typeName: Curve.$typeName,
-      fullTypeName: composeSuiType(
-        Curve.$typeName,
-        ...[],
-      ) as `0x2::groth16::Curve`,
+      get typeName() {
+        return Curve.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Curve.$typeName,
+          ...[],
+        ) as `0x2::groth16::Curve`
+      },
       typeArgs: [] as [],
       isPhantom: Curve.$isPhantom,
       reifiedTypeArgs: [],
@@ -273,11 +277,15 @@ export class PreparedVerifyingKey implements StructClass {
   static reified(): PreparedVerifyingKeyReified {
     const reifiedBcs = PreparedVerifyingKey.bcs
     return {
-      typeName: PreparedVerifyingKey.$typeName,
-      fullTypeName: composeSuiType(
-        PreparedVerifyingKey.$typeName,
-        ...[],
-      ) as `0x2::groth16::PreparedVerifyingKey`,
+      get typeName() {
+        return PreparedVerifyingKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PreparedVerifyingKey.$typeName,
+          ...[],
+        ) as `0x2::groth16::PreparedVerifyingKey`
+      },
       typeArgs: [] as [],
       isPhantom: PreparedVerifyingKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -481,11 +489,15 @@ export class PublicProofInputs implements StructClass {
   static reified(): PublicProofInputsReified {
     const reifiedBcs = PublicProofInputs.bcs
     return {
-      typeName: PublicProofInputs.$typeName,
-      fullTypeName: composeSuiType(
-        PublicProofInputs.$typeName,
-        ...[],
-      ) as `0x2::groth16::PublicProofInputs`,
+      get typeName() {
+        return PublicProofInputs.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PublicProofInputs.$typeName,
+          ...[],
+        ) as `0x2::groth16::PublicProofInputs`
+      },
       typeArgs: [] as [],
       isPhantom: PublicProofInputs.$isPhantom,
       reifiedTypeArgs: [],
@@ -664,11 +676,15 @@ export class ProofPoints implements StructClass {
   static reified(): ProofPointsReified {
     const reifiedBcs = ProofPoints.bcs
     return {
-      typeName: ProofPoints.$typeName,
-      fullTypeName: composeSuiType(
-        ProofPoints.$typeName,
-        ...[],
-      ) as `0x2::groth16::ProofPoints`,
+      get typeName() {
+        return ProofPoints.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ProofPoints.$typeName,
+          ...[],
+        ) as `0x2::groth16::ProofPoints`
+      },
       typeArgs: [] as [],
       isPhantom: ProofPoints.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/group-ops/structs.ts
+++ b/ts/examples/gen/sui/group-ops/structs.ts
@@ -84,12 +84,18 @@ export class Element<T extends PhantomTypeArgument> implements StructClass {
   ): ElementReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Element.bcs
     return {
-      typeName: Element.$typeName,
-      fullTypeName: composeSuiType(
-        Element.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::group_ops::Element<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Element.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Element.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::group_ops::Element<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Element.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Element.fromFields(T, fields),

--- a/ts/examples/gen/sui/kiosk-extension/structs.ts
+++ b/ts/examples/gen/sui/kiosk-extension/structs.ts
@@ -186,11 +186,15 @@ export class Extension implements StructClass {
   static reified(): ExtensionReified {
     const reifiedBcs = Extension.bcs
     return {
-      typeName: Extension.$typeName,
-      fullTypeName: composeSuiType(
-        Extension.$typeName,
-        ...[],
-      ) as `0x2::kiosk_extension::Extension`,
+      get typeName() {
+        return Extension.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Extension.$typeName,
+          ...[],
+        ) as `0x2::kiosk_extension::Extension`
+      },
       typeArgs: [] as [],
       isPhantom: Extension.$isPhantom,
       reifiedTypeArgs: [],
@@ -389,12 +393,18 @@ export class ExtensionKey<Ext extends PhantomTypeArgument> implements StructClas
   ): ExtensionKeyReified<ToPhantomTypeArgument<Ext>> {
     const reifiedBcs = ExtensionKey.bcs
     return {
-      typeName: ExtensionKey.$typeName,
-      fullTypeName: composeSuiType(
-        ExtensionKey.$typeName,
-        ...[extractType(Ext)],
-      ) as `0x2::kiosk_extension::ExtensionKey<${PhantomToTypeStr<ToPhantomTypeArgument<Ext>>}>`,
-      typeArgs: [extractType(Ext)] as [PhantomToTypeStr<ToPhantomTypeArgument<Ext>>],
+      get typeName() {
+        return ExtensionKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ExtensionKey.$typeName,
+          ...[extractType(Ext)],
+        ) as `0x2::kiosk_extension::ExtensionKey<${PhantomToTypeStr<ToPhantomTypeArgument<Ext>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Ext)] as [PhantomToTypeStr<ToPhantomTypeArgument<Ext>>]
+      },
       isPhantom: ExtensionKey.$isPhantom,
       reifiedTypeArgs: [Ext],
       fromFields: (fields: Record<string, any>) => ExtensionKey.fromFields(Ext, fields),

--- a/ts/examples/gen/sui/kiosk/structs.ts
+++ b/ts/examples/gen/sui/kiosk/structs.ts
@@ -217,11 +217,15 @@ export class Kiosk implements StructClass {
   static reified(): KioskReified {
     const reifiedBcs = Kiosk.bcs
     return {
-      typeName: Kiosk.$typeName,
-      fullTypeName: composeSuiType(
-        Kiosk.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Kiosk`,
+      get typeName() {
+        return Kiosk.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Kiosk.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Kiosk`
+      },
       typeArgs: [] as [],
       isPhantom: Kiosk.$isPhantom,
       reifiedTypeArgs: [],
@@ -433,11 +437,15 @@ export class KioskOwnerCap implements StructClass {
   static reified(): KioskOwnerCapReified {
     const reifiedBcs = KioskOwnerCap.bcs
     return {
-      typeName: KioskOwnerCap.$typeName,
-      fullTypeName: composeSuiType(
-        KioskOwnerCap.$typeName,
-        ...[],
-      ) as `0x2::kiosk::KioskOwnerCap`,
+      get typeName() {
+        return KioskOwnerCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          KioskOwnerCap.$typeName,
+          ...[],
+        ) as `0x2::kiosk::KioskOwnerCap`
+      },
       typeArgs: [] as [],
       isPhantom: KioskOwnerCap.$isPhantom,
       reifiedTypeArgs: [],
@@ -654,12 +662,18 @@ export class PurchaseCap<T extends PhantomTypeArgument> implements StructClass {
   ): PurchaseCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = PurchaseCap.bcs
     return {
-      typeName: PurchaseCap.$typeName,
-      fullTypeName: composeSuiType(
-        PurchaseCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::kiosk::PurchaseCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return PurchaseCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PurchaseCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::kiosk::PurchaseCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: PurchaseCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => PurchaseCap.fromFields(T, fields),
@@ -924,11 +938,15 @@ export class Borrow implements StructClass {
   static reified(): BorrowReified {
     const reifiedBcs = Borrow.bcs
     return {
-      typeName: Borrow.$typeName,
-      fullTypeName: composeSuiType(
-        Borrow.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Borrow`,
+      get typeName() {
+        return Borrow.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Borrow.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Borrow`
+      },
       typeArgs: [] as [],
       isPhantom: Borrow.$isPhantom,
       reifiedTypeArgs: [],
@@ -1112,11 +1130,15 @@ export class Item implements StructClass {
   static reified(): ItemReified {
     const reifiedBcs = Item.bcs
     return {
-      typeName: Item.$typeName,
-      fullTypeName: composeSuiType(
-        Item.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Item`,
+      get typeName() {
+        return Item.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Item.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Item`
+      },
       typeArgs: [] as [],
       isPhantom: Item.$isPhantom,
       reifiedTypeArgs: [],
@@ -1302,11 +1324,15 @@ export class Listing implements StructClass {
   static reified(): ListingReified {
     const reifiedBcs = Listing.bcs
     return {
-      typeName: Listing.$typeName,
-      fullTypeName: composeSuiType(
-        Listing.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Listing`,
+      get typeName() {
+        return Listing.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Listing.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Listing`
+      },
       typeArgs: [] as [],
       isPhantom: Listing.$isPhantom,
       reifiedTypeArgs: [],
@@ -1494,11 +1520,15 @@ export class Lock implements StructClass {
   static reified(): LockReified {
     const reifiedBcs = Lock.bcs
     return {
-      typeName: Lock.$typeName,
-      fullTypeName: composeSuiType(
-        Lock.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Lock`,
+      get typeName() {
+        return Lock.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Lock.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Lock`
+      },
       typeArgs: [] as [],
       isPhantom: Lock.$isPhantom,
       reifiedTypeArgs: [],
@@ -1694,12 +1724,18 @@ export class ItemListed<T extends PhantomTypeArgument> implements StructClass {
   ): ItemListedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = ItemListed.bcs
     return {
-      typeName: ItemListed.$typeName,
-      fullTypeName: composeSuiType(
-        ItemListed.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::kiosk::ItemListed<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return ItemListed.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ItemListed.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::kiosk::ItemListed<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: ItemListed.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => ItemListed.fromFields(T, fields),
@@ -1975,12 +2011,18 @@ export class ItemPurchased<T extends PhantomTypeArgument> implements StructClass
   ): ItemPurchasedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = ItemPurchased.bcs
     return {
-      typeName: ItemPurchased.$typeName,
-      fullTypeName: composeSuiType(
-        ItemPurchased.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::kiosk::ItemPurchased<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return ItemPurchased.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ItemPurchased.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::kiosk::ItemPurchased<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: ItemPurchased.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => ItemPurchased.fromFields(T, fields),
@@ -2245,12 +2287,18 @@ export class ItemDelisted<T extends PhantomTypeArgument> implements StructClass 
   ): ItemDelistedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = ItemDelisted.bcs
     return {
-      typeName: ItemDelisted.$typeName,
-      fullTypeName: composeSuiType(
-        ItemDelisted.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::kiosk::ItemDelisted<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return ItemDelisted.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ItemDelisted.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::kiosk::ItemDelisted<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: ItemDelisted.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => ItemDelisted.fromFields(T, fields),

--- a/ts/examples/gen/sui/linked-table/structs.ts
+++ b/ts/examples/gen/sui/linked-table/structs.ts
@@ -123,17 +123,23 @@ export class LinkedTable<K extends TypeArgument, V extends PhantomTypeArgument>
   ): LinkedTableReified<ToTypeArgument<K>, ToPhantomTypeArgument<V>> {
     const reifiedBcs = LinkedTable.bcs(toBcs(K))
     return {
-      typeName: LinkedTable.$typeName,
-      fullTypeName: composeSuiType(
-        LinkedTable.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::linked_table::LinkedTable<${ToTypeStr<ToTypeArgument<K>>}, ${PhantomToTypeStr<
-        ToPhantomTypeArgument<V>
-      >}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<K>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<V>>,
-      ],
+      get typeName() {
+        return LinkedTable.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          LinkedTable.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::linked_table::LinkedTable<${ToTypeStr<ToTypeArgument<K>>}, ${PhantomToTypeStr<
+          ToPhantomTypeArgument<V>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<K>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<V>>,
+        ]
+      },
       isPhantom: LinkedTable.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => LinkedTable.fromFields([K, V], fields),
@@ -440,17 +446,23 @@ export class Node<K extends TypeArgument, V extends TypeArgument> implements Str
   ): NodeReified<ToTypeArgument<K>, ToTypeArgument<V>> {
     const reifiedBcs = Node.bcs(toBcs(K), toBcs(V))
     return {
-      typeName: Node.$typeName,
-      fullTypeName: composeSuiType(
-        Node.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::linked_table::Node<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<
-        ToTypeArgument<V>
-      >}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<K>>,
-        ToTypeStr<ToTypeArgument<V>>,
-      ],
+      get typeName() {
+        return Node.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Node.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::linked_table::Node<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<
+          ToTypeArgument<V>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<K>>,
+          ToTypeStr<ToTypeArgument<V>>,
+        ]
+      },
       isPhantom: Node.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => Node.fromFields([K, V], fields),

--- a/ts/examples/gen/sui/nitro-attestation/structs.ts
+++ b/ts/examples/gen/sui/nitro-attestation/structs.ts
@@ -80,11 +80,15 @@ export class PCREntry implements StructClass {
   static reified(): PCREntryReified {
     const reifiedBcs = PCREntry.bcs
     return {
-      typeName: PCREntry.$typeName,
-      fullTypeName: composeSuiType(
-        PCREntry.$typeName,
-        ...[],
-      ) as `0x2::nitro_attestation::PCREntry`,
+      get typeName() {
+        return PCREntry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PCREntry.$typeName,
+          ...[],
+        ) as `0x2::nitro_attestation::PCREntry`
+      },
       typeArgs: [] as [],
       isPhantom: PCREntry.$isPhantom,
       reifiedTypeArgs: [],
@@ -323,11 +327,15 @@ export class NitroAttestationDocument implements StructClass {
   static reified(): NitroAttestationDocumentReified {
     const reifiedBcs = NitroAttestationDocument.bcs
     return {
-      typeName: NitroAttestationDocument.$typeName,
-      fullTypeName: composeSuiType(
-        NitroAttestationDocument.$typeName,
-        ...[],
-      ) as `0x2::nitro_attestation::NitroAttestationDocument`,
+      get typeName() {
+        return NitroAttestationDocument.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          NitroAttestationDocument.$typeName,
+          ...[],
+        ) as `0x2::nitro_attestation::NitroAttestationDocument`
+      },
       typeArgs: [] as [],
       isPhantom: NitroAttestationDocument.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/object-bag/structs.ts
+++ b/ts/examples/gen/sui/object-bag/structs.ts
@@ -86,11 +86,15 @@ export class ObjectBag implements StructClass {
   static reified(): ObjectBagReified {
     const reifiedBcs = ObjectBag.bcs
     return {
-      typeName: ObjectBag.$typeName,
-      fullTypeName: composeSuiType(
-        ObjectBag.$typeName,
-        ...[],
-      ) as `0x2::object_bag::ObjectBag`,
+      get typeName() {
+        return ObjectBag.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ObjectBag.$typeName,
+          ...[],
+        ) as `0x2::object_bag::ObjectBag`
+      },
       typeArgs: [] as [],
       isPhantom: ObjectBag.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/object-table/structs.ts
+++ b/ts/examples/gen/sui/object-table/structs.ts
@@ -108,17 +108,23 @@ export class ObjectTable<K extends PhantomTypeArgument, V extends PhantomTypeArg
   ): ObjectTableReified<ToPhantomTypeArgument<K>, ToPhantomTypeArgument<V>> {
     const reifiedBcs = ObjectTable.bcs
     return {
-      typeName: ObjectTable.$typeName,
-      fullTypeName: composeSuiType(
-        ObjectTable.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::object_table::ObjectTable<${PhantomToTypeStr<
-        ToPhantomTypeArgument<K>
-      >}, ${PhantomToTypeStr<ToPhantomTypeArgument<V>>}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        PhantomToTypeStr<ToPhantomTypeArgument<K>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<V>>,
-      ],
+      get typeName() {
+        return ObjectTable.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ObjectTable.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::object_table::ObjectTable<${PhantomToTypeStr<
+          ToPhantomTypeArgument<K>
+        >}, ${PhantomToTypeStr<ToPhantomTypeArgument<V>>}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          PhantomToTypeStr<ToPhantomTypeArgument<K>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<V>>,
+        ]
+      },
       isPhantom: ObjectTable.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => ObjectTable.fromFields([K, V], fields),

--- a/ts/examples/gen/sui/object/structs.ts
+++ b/ts/examples/gen/sui/object/structs.ts
@@ -80,11 +80,15 @@ export class ID implements StructClass {
   static reified(): IDReified {
     const reifiedBcs = ID.bcs
     return {
-      typeName: ID.$typeName,
-      fullTypeName: composeSuiType(
-        ID.$typeName,
-        ...[],
-      ) as `0x2::object::ID`,
+      get typeName() {
+        return ID.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ID.$typeName,
+          ...[],
+        ) as `0x2::object::ID`
+      },
       typeArgs: [] as [],
       isPhantom: ID.$isPhantom,
       reifiedTypeArgs: [],
@@ -273,11 +277,15 @@ export class UID implements StructClass {
   static reified(): UIDReified {
     const reifiedBcs = UID.bcs
     return {
-      typeName: UID.$typeName,
-      fullTypeName: composeSuiType(
-        UID.$typeName,
-        ...[],
-      ) as `0x2::object::UID`,
+      get typeName() {
+        return UID.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UID.$typeName,
+          ...[],
+        ) as `0x2::object::UID`
+      },
       typeArgs: [] as [],
       isPhantom: UID.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/package/structs.ts
+++ b/ts/examples/gen/sui/package/structs.ts
@@ -95,11 +95,15 @@ export class Publisher implements StructClass {
   static reified(): PublisherReified {
     const reifiedBcs = Publisher.bcs
     return {
-      typeName: Publisher.$typeName,
-      fullTypeName: composeSuiType(
-        Publisher.$typeName,
-        ...[],
-      ) as `0x2::package::Publisher`,
+      get typeName() {
+        return Publisher.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Publisher.$typeName,
+          ...[],
+        ) as `0x2::package::Publisher`
+      },
       typeArgs: [] as [],
       isPhantom: Publisher.$isPhantom,
       reifiedTypeArgs: [],
@@ -312,11 +316,15 @@ export class UpgradeCap implements StructClass {
   static reified(): UpgradeCapReified {
     const reifiedBcs = UpgradeCap.bcs
     return {
-      typeName: UpgradeCap.$typeName,
-      fullTypeName: composeSuiType(
-        UpgradeCap.$typeName,
-        ...[],
-      ) as `0x2::package::UpgradeCap`,
+      get typeName() {
+        return UpgradeCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UpgradeCap.$typeName,
+          ...[],
+        ) as `0x2::package::UpgradeCap`
+      },
       typeArgs: [] as [],
       isPhantom: UpgradeCap.$isPhantom,
       reifiedTypeArgs: [],
@@ -551,11 +559,15 @@ export class UpgradeTicket implements StructClass {
   static reified(): UpgradeTicketReified {
     const reifiedBcs = UpgradeTicket.bcs
     return {
-      typeName: UpgradeTicket.$typeName,
-      fullTypeName: composeSuiType(
-        UpgradeTicket.$typeName,
-        ...[],
-      ) as `0x2::package::UpgradeTicket`,
+      get typeName() {
+        return UpgradeTicket.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UpgradeTicket.$typeName,
+          ...[],
+        ) as `0x2::package::UpgradeTicket`
+      },
       typeArgs: [] as [],
       isPhantom: UpgradeTicket.$isPhantom,
       reifiedTypeArgs: [],
@@ -763,11 +775,15 @@ export class UpgradeReceipt implements StructClass {
   static reified(): UpgradeReceiptReified {
     const reifiedBcs = UpgradeReceipt.bcs
     return {
-      typeName: UpgradeReceipt.$typeName,
-      fullTypeName: composeSuiType(
-        UpgradeReceipt.$typeName,
-        ...[],
-      ) as `0x2::package::UpgradeReceipt`,
+      get typeName() {
+        return UpgradeReceipt.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UpgradeReceipt.$typeName,
+          ...[],
+        ) as `0x2::package::UpgradeReceipt`
+      },
       typeArgs: [] as [],
       isPhantom: UpgradeReceipt.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/party/structs.ts
+++ b/ts/examples/gen/sui/party/structs.ts
@@ -88,11 +88,15 @@ export class Party implements StructClass {
   static reified(): PartyReified {
     const reifiedBcs = Party.bcs
     return {
-      typeName: Party.$typeName,
-      fullTypeName: composeSuiType(
-        Party.$typeName,
-        ...[],
-      ) as `0x2::party::Party`,
+      get typeName() {
+        return Party.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Party.$typeName,
+          ...[],
+        ) as `0x2::party::Party`
+      },
       typeArgs: [] as [],
       isPhantom: Party.$isPhantom,
       reifiedTypeArgs: [],
@@ -288,11 +292,15 @@ export class Permissions implements StructClass {
   static reified(): PermissionsReified {
     const reifiedBcs = Permissions.bcs
     return {
-      typeName: Permissions.$typeName,
-      fullTypeName: composeSuiType(
-        Permissions.$typeName,
-        ...[],
-      ) as `0x2::party::Permissions`,
+      get typeName() {
+        return Permissions.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Permissions.$typeName,
+          ...[],
+        ) as `0x2::party::Permissions`
+      },
       typeArgs: [] as [],
       isPhantom: Permissions.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/priority-queue/structs.ts
+++ b/ts/examples/gen/sui/priority-queue/structs.ts
@@ -95,12 +95,18 @@ export class PriorityQueue<T extends TypeArgument> implements StructClass {
   ): PriorityQueueReified<ToTypeArgument<T>> {
     const reifiedBcs = PriorityQueue.bcs(toBcs(T))
     return {
-      typeName: PriorityQueue.$typeName,
-      fullTypeName: composeSuiType(
-        PriorityQueue.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::priority_queue::PriorityQueue<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return PriorityQueue.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PriorityQueue.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::priority_queue::PriorityQueue<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: PriorityQueue.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => PriorityQueue.fromFields(T, fields),
@@ -353,12 +359,18 @@ export class Entry<T extends TypeArgument> implements StructClass {
   ): EntryReified<ToTypeArgument<T>> {
     const reifiedBcs = Entry.bcs(toBcs(T))
     return {
-      typeName: Entry.$typeName,
-      fullTypeName: composeSuiType(
-        Entry.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::priority_queue::Entry<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return Entry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Entry.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::priority_queue::Entry<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: Entry.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Entry.fromFields(T, fields),

--- a/ts/examples/gen/sui/random/structs.ts
+++ b/ts/examples/gen/sui/random/structs.ts
@@ -85,11 +85,15 @@ export class Random implements StructClass {
   static reified(): RandomReified {
     const reifiedBcs = Random.bcs
     return {
-      typeName: Random.$typeName,
-      fullTypeName: composeSuiType(
-        Random.$typeName,
-        ...[],
-      ) as `0x2::random::Random`,
+      get typeName() {
+        return Random.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Random.$typeName,
+          ...[],
+        ) as `0x2::random::Random`
+      },
       typeArgs: [] as [],
       isPhantom: Random.$isPhantom,
       reifiedTypeArgs: [],
@@ -284,11 +288,15 @@ export class RandomInner implements StructClass {
   static reified(): RandomInnerReified {
     const reifiedBcs = RandomInner.bcs
     return {
-      typeName: RandomInner.$typeName,
-      fullTypeName: composeSuiType(
-        RandomInner.$typeName,
-        ...[],
-      ) as `0x2::random::RandomInner`,
+      get typeName() {
+        return RandomInner.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RandomInner.$typeName,
+          ...[],
+        ) as `0x2::random::RandomInner`
+      },
       typeArgs: [] as [],
       isPhantom: RandomInner.$isPhantom,
       reifiedTypeArgs: [],
@@ -491,11 +499,15 @@ export class RandomGenerator implements StructClass {
   static reified(): RandomGeneratorReified {
     const reifiedBcs = RandomGenerator.bcs
     return {
-      typeName: RandomGenerator.$typeName,
-      fullTypeName: composeSuiType(
-        RandomGenerator.$typeName,
-        ...[],
-      ) as `0x2::random::RandomGenerator`,
+      get typeName() {
+        return RandomGenerator.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RandomGenerator.$typeName,
+          ...[],
+        ) as `0x2::random::RandomGenerator`
+      },
       typeArgs: [] as [],
       isPhantom: RandomGenerator.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/sui/structs.ts
+++ b/ts/examples/gen/sui/sui/structs.ts
@@ -76,11 +76,15 @@ export class SUI implements StructClass {
   static reified(): SUIReified {
     const reifiedBcs = SUI.bcs
     return {
-      typeName: SUI.$typeName,
-      fullTypeName: composeSuiType(
-        SUI.$typeName,
-        ...[],
-      ) as `0x2::sui::SUI`,
+      get typeName() {
+        return SUI.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          SUI.$typeName,
+          ...[],
+        ) as `0x2::sui::SUI`
+      },
       typeArgs: [] as [],
       isPhantom: SUI.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/table-vec/structs.ts
+++ b/ts/examples/gen/sui/table-vec/structs.ts
@@ -87,12 +87,18 @@ export class TableVec<Element extends PhantomTypeArgument> implements StructClas
   ): TableVecReified<ToPhantomTypeArgument<Element>> {
     const reifiedBcs = TableVec.bcs
     return {
-      typeName: TableVec.$typeName,
-      fullTypeName: composeSuiType(
-        TableVec.$typeName,
-        ...[extractType(Element)],
-      ) as `0x2::table_vec::TableVec<${PhantomToTypeStr<ToPhantomTypeArgument<Element>>}>`,
-      typeArgs: [extractType(Element)] as [PhantomToTypeStr<ToPhantomTypeArgument<Element>>],
+      get typeName() {
+        return TableVec.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TableVec.$typeName,
+          ...[extractType(Element)],
+        ) as `0x2::table_vec::TableVec<${PhantomToTypeStr<ToPhantomTypeArgument<Element>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Element)] as [PhantomToTypeStr<ToPhantomTypeArgument<Element>>]
+      },
       isPhantom: TableVec.$isPhantom,
       reifiedTypeArgs: [Element],
       fromFields: (fields: Record<string, any>) => TableVec.fromFields(Element, fields),

--- a/ts/examples/gen/sui/table/structs.ts
+++ b/ts/examples/gen/sui/table/structs.ts
@@ -118,17 +118,23 @@ export class Table<K extends PhantomTypeArgument, V extends PhantomTypeArgument>
   ): TableReified<ToPhantomTypeArgument<K>, ToPhantomTypeArgument<V>> {
     const reifiedBcs = Table.bcs
     return {
-      typeName: Table.$typeName,
-      fullTypeName: composeSuiType(
-        Table.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::table::Table<${PhantomToTypeStr<ToPhantomTypeArgument<K>>}, ${PhantomToTypeStr<
-        ToPhantomTypeArgument<V>
-      >}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        PhantomToTypeStr<ToPhantomTypeArgument<K>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<V>>,
-      ],
+      get typeName() {
+        return Table.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Table.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::table::Table<${PhantomToTypeStr<ToPhantomTypeArgument<K>>}, ${PhantomToTypeStr<
+          ToPhantomTypeArgument<V>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          PhantomToTypeStr<ToPhantomTypeArgument<K>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<V>>,
+        ]
+      },
       isPhantom: Table.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => Table.fromFields([K, V], fields),

--- a/ts/examples/gen/sui/token/structs.ts
+++ b/ts/examples/gen/sui/token/structs.ts
@@ -118,12 +118,18 @@ export class Token<T extends PhantomTypeArgument> implements StructClass {
   ): TokenReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Token.bcs
     return {
-      typeName: Token.$typeName,
-      fullTypeName: composeSuiType(
-        Token.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::Token<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Token.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Token.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::Token<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Token.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Token.fromFields(T, fields),
@@ -383,12 +389,18 @@ export class TokenPolicyCap<T extends PhantomTypeArgument> implements StructClas
   ): TokenPolicyCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TokenPolicyCap.bcs
     return {
-      typeName: TokenPolicyCap.$typeName,
-      fullTypeName: composeSuiType(
-        TokenPolicyCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::TokenPolicyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TokenPolicyCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TokenPolicyCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::TokenPolicyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TokenPolicyCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TokenPolicyCap.fromFields(T, fields),
@@ -685,12 +697,18 @@ export class TokenPolicy<T extends PhantomTypeArgument> implements StructClass {
   ): TokenPolicyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TokenPolicy.bcs
     return {
-      typeName: TokenPolicy.$typeName,
-      fullTypeName: composeSuiType(
-        TokenPolicy.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::TokenPolicy<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TokenPolicy.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TokenPolicy.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::TokenPolicy<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TokenPolicy.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TokenPolicy.fromFields(T, fields),
@@ -1015,12 +1033,18 @@ export class ActionRequest<T extends PhantomTypeArgument> implements StructClass
   ): ActionRequestReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = ActionRequest.bcs
     return {
-      typeName: ActionRequest.$typeName,
-      fullTypeName: composeSuiType(
-        ActionRequest.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::ActionRequest<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return ActionRequest.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ActionRequest.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::ActionRequest<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: ActionRequest.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => ActionRequest.fromFields(T, fields),
@@ -1317,12 +1341,18 @@ export class RuleKey<T extends PhantomTypeArgument> implements StructClass {
   ): RuleKeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = RuleKey.bcs
     return {
-      typeName: RuleKey.$typeName,
-      fullTypeName: composeSuiType(
-        RuleKey.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::RuleKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return RuleKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RuleKey.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::RuleKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: RuleKey.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => RuleKey.fromFields(T, fields),
@@ -1589,12 +1619,18 @@ export class TokenPolicyCreated<T extends PhantomTypeArgument> implements Struct
   ): TokenPolicyCreatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TokenPolicyCreated.bcs
     return {
-      typeName: TokenPolicyCreated.$typeName,
-      fullTypeName: composeSuiType(
-        TokenPolicyCreated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::TokenPolicyCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TokenPolicyCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TokenPolicyCreated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::TokenPolicyCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TokenPolicyCreated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TokenPolicyCreated.fromFields(T, fields),

--- a/ts/examples/gen/sui/transfer-policy/structs.ts
+++ b/ts/examples/gen/sui/transfer-policy/structs.ts
@@ -162,12 +162,18 @@ export class TransferRequest<T extends PhantomTypeArgument> implements StructCla
   ): TransferRequestReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferRequest.bcs
     return {
-      typeName: TransferRequest.$typeName,
-      fullTypeName: composeSuiType(
-        TransferRequest.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferRequest<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferRequest.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferRequest.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferRequest<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferRequest.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferRequest.fromFields(T, fields),
@@ -469,12 +475,18 @@ export class TransferPolicy<T extends PhantomTypeArgument> implements StructClas
   ): TransferPolicyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferPolicy.bcs
     return {
-      typeName: TransferPolicy.$typeName,
-      fullTypeName: composeSuiType(
-        TransferPolicy.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferPolicy<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferPolicy.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferPolicy.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferPolicy<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferPolicy.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferPolicy.fromFields(T, fields),
@@ -743,12 +755,20 @@ export class TransferPolicyCap<T extends PhantomTypeArgument> implements StructC
   ): TransferPolicyCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferPolicyCap.bcs
     return {
-      typeName: TransferPolicyCap.$typeName,
-      fullTypeName: composeSuiType(
-        TransferPolicyCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferPolicyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferPolicyCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferPolicyCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferPolicyCap<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferPolicyCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferPolicyCap.fromFields(T, fields),
@@ -1009,14 +1029,20 @@ export class TransferPolicyCreated<T extends PhantomTypeArgument> implements Str
   ): TransferPolicyCreatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferPolicyCreated.bcs
     return {
-      typeName: TransferPolicyCreated.$typeName,
-      fullTypeName: composeSuiType(
-        TransferPolicyCreated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferPolicyCreated<${PhantomToTypeStr<
-        ToPhantomTypeArgument<T>
-      >}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferPolicyCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferPolicyCreated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferPolicyCreated<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferPolicyCreated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferPolicyCreated.fromFields(T, fields),
@@ -1275,14 +1301,20 @@ export class TransferPolicyDestroyed<T extends PhantomTypeArgument> implements S
   ): TransferPolicyDestroyedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferPolicyDestroyed.bcs
     return {
-      typeName: TransferPolicyDestroyed.$typeName,
-      fullTypeName: composeSuiType(
-        TransferPolicyDestroyed.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferPolicyDestroyed<${PhantomToTypeStr<
-        ToPhantomTypeArgument<T>
-      >}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferPolicyDestroyed.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferPolicyDestroyed.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferPolicyDestroyed<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferPolicyDestroyed.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferPolicyDestroyed.fromFields(T, fields),
@@ -1534,12 +1566,18 @@ export class RuleKey<T extends PhantomTypeArgument> implements StructClass {
   ): RuleKeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = RuleKey.bcs
     return {
-      typeName: RuleKey.$typeName,
-      fullTypeName: composeSuiType(
-        RuleKey.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::RuleKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return RuleKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RuleKey.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::RuleKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: RuleKey.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => RuleKey.fromFields(T, fields),

--- a/ts/examples/gen/sui/transfer/structs.ts
+++ b/ts/examples/gen/sui/transfer/structs.ts
@@ -96,12 +96,18 @@ export class Receiving<T extends PhantomTypeArgument> implements StructClass {
   ): ReceivingReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Receiving.bcs
     return {
-      typeName: Receiving.$typeName,
-      fullTypeName: composeSuiType(
-        Receiving.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer::Receiving<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Receiving.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Receiving.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer::Receiving<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Receiving.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Receiving.fromFields(T, fields),

--- a/ts/examples/gen/sui/tx-context/structs.ts
+++ b/ts/examples/gen/sui/tx-context/structs.ts
@@ -110,11 +110,15 @@ export class TxContext implements StructClass {
   static reified(): TxContextReified {
     const reifiedBcs = TxContext.bcs
     return {
-      typeName: TxContext.$typeName,
-      fullTypeName: composeSuiType(
-        TxContext.$typeName,
-        ...[],
-      ) as `0x2::tx_context::TxContext`,
+      get typeName() {
+        return TxContext.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TxContext.$typeName,
+          ...[],
+        ) as `0x2::tx_context::TxContext`
+      },
       typeArgs: [] as [],
       isPhantom: TxContext.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/url/structs.ts
+++ b/ts/examples/gen/sui/url/structs.ts
@@ -74,11 +74,15 @@ export class Url implements StructClass {
   static reified(): UrlReified {
     const reifiedBcs = Url.bcs
     return {
-      typeName: Url.$typeName,
-      fullTypeName: composeSuiType(
-        Url.$typeName,
-        ...[],
-      ) as `0x2::url::Url`,
+      get typeName() {
+        return Url.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Url.$typeName,
+          ...[],
+        ) as `0x2::url::Url`
+      },
       typeArgs: [] as [],
       isPhantom: Url.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/vec-map/structs.ts
+++ b/ts/examples/gen/sui/vec-map/structs.ts
@@ -94,15 +94,23 @@ export class VecMap<K extends TypeArgument, V extends TypeArgument> implements S
   ): VecMapReified<ToTypeArgument<K>, ToTypeArgument<V>> {
     const reifiedBcs = VecMap.bcs(toBcs(K), toBcs(V))
     return {
-      typeName: VecMap.$typeName,
-      fullTypeName: composeSuiType(
-        VecMap.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::vec_map::VecMap<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<ToTypeArgument<V>>}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<K>>,
-        ToTypeStr<ToTypeArgument<V>>,
-      ],
+      get typeName() {
+        return VecMap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VecMap.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::vec_map::VecMap<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<
+          ToTypeArgument<V>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<K>>,
+          ToTypeStr<ToTypeArgument<V>>,
+        ]
+      },
       isPhantom: VecMap.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => VecMap.fromFields([K, V], fields),
@@ -378,15 +386,21 @@ export class Entry<K extends TypeArgument, V extends TypeArgument> implements St
   ): EntryReified<ToTypeArgument<K>, ToTypeArgument<V>> {
     const reifiedBcs = Entry.bcs(toBcs(K), toBcs(V))
     return {
-      typeName: Entry.$typeName,
-      fullTypeName: composeSuiType(
-        Entry.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::vec_map::Entry<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<ToTypeArgument<V>>}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<K>>,
-        ToTypeStr<ToTypeArgument<V>>,
-      ],
+      get typeName() {
+        return Entry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Entry.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::vec_map::Entry<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<ToTypeArgument<V>>}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<K>>,
+          ToTypeStr<ToTypeArgument<V>>,
+        ]
+      },
       isPhantom: Entry.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => Entry.fromFields([K, V], fields),

--- a/ts/examples/gen/sui/vec-set/structs.ts
+++ b/ts/examples/gen/sui/vec-set/structs.ts
@@ -89,12 +89,18 @@ export class VecSet<K extends TypeArgument> implements StructClass {
   ): VecSetReified<ToTypeArgument<K>> {
     const reifiedBcs = VecSet.bcs(toBcs(K))
     return {
-      typeName: VecSet.$typeName,
-      fullTypeName: composeSuiType(
-        VecSet.$typeName,
-        ...[extractType(K)],
-      ) as `0x2::vec_set::VecSet<${ToTypeStr<ToTypeArgument<K>>}>`,
-      typeArgs: [extractType(K)] as [ToTypeStr<ToTypeArgument<K>>],
+      get typeName() {
+        return VecSet.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VecSet.$typeName,
+          ...[extractType(K)],
+        ) as `0x2::vec_set::VecSet<${ToTypeStr<ToTypeArgument<K>>}>`
+      },
+      get typeArgs() {
+        return [extractType(K)] as [ToTypeStr<ToTypeArgument<K>>]
+      },
       isPhantom: VecSet.$isPhantom,
       reifiedTypeArgs: [K],
       fromFields: (fields: Record<string, any>) => VecSet.fromFields(K, fields),

--- a/ts/examples/gen/sui/versioned/structs.ts
+++ b/ts/examples/gen/sui/versioned/structs.ts
@@ -83,11 +83,15 @@ export class Versioned implements StructClass {
   static reified(): VersionedReified {
     const reifiedBcs = Versioned.bcs
     return {
-      typeName: Versioned.$typeName,
-      fullTypeName: composeSuiType(
-        Versioned.$typeName,
-        ...[],
-      ) as `0x2::versioned::Versioned`,
+      get typeName() {
+        return Versioned.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Versioned.$typeName,
+          ...[],
+        ) as `0x2::versioned::Versioned`
+      },
       typeArgs: [] as [],
       isPhantom: Versioned.$isPhantom,
       reifiedTypeArgs: [],
@@ -279,11 +283,15 @@ export class VersionChangeCap implements StructClass {
   static reified(): VersionChangeCapReified {
     const reifiedBcs = VersionChangeCap.bcs
     return {
-      typeName: VersionChangeCap.$typeName,
-      fullTypeName: composeSuiType(
-        VersionChangeCap.$typeName,
-        ...[],
-      ) as `0x2::versioned::VersionChangeCap`,
+      get typeName() {
+        return VersionChangeCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VersionChangeCap.$typeName,
+          ...[],
+        ) as `0x2::versioned::VersionChangeCap`
+      },
       typeArgs: [] as [],
       isPhantom: VersionChangeCap.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/zklogin-verified-id/structs.ts
+++ b/ts/examples/gen/sui/zklogin-verified-id/structs.ts
@@ -106,11 +106,15 @@ export class VerifiedID implements StructClass {
   static reified(): VerifiedIDReified {
     const reifiedBcs = VerifiedID.bcs
     return {
-      typeName: VerifiedID.$typeName,
-      fullTypeName: composeSuiType(
-        VerifiedID.$typeName,
-        ...[],
-      ) as `0x2::zklogin_verified_id::VerifiedID`,
+      get typeName() {
+        return VerifiedID.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VerifiedID.$typeName,
+          ...[],
+        ) as `0x2::zklogin_verified_id::VerifiedID`
+      },
       typeArgs: [] as [],
       isPhantom: VerifiedID.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/examples/gen/sui/zklogin-verified-issuer/structs.ts
+++ b/ts/examples/gen/sui/zklogin-verified-issuer/structs.ts
@@ -91,11 +91,15 @@ export class VerifiedIssuer implements StructClass {
   static reified(): VerifiedIssuerReified {
     const reifiedBcs = VerifiedIssuer.bcs
     return {
-      typeName: VerifiedIssuer.$typeName,
-      fullTypeName: composeSuiType(
-        VerifiedIssuer.$typeName,
-        ...[],
-      ) as `0x2::zklogin_verified_issuer::VerifiedIssuer`,
+      get typeName() {
+        return VerifiedIssuer.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VerifiedIssuer.$typeName,
+          ...[],
+        ) as `0x2::zklogin_verified_issuer::VerifiedIssuer`
+      },
       typeArgs: [] as [],
       isPhantom: VerifiedIssuer.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/_framework/env.ts
+++ b/ts/tests/gen/_framework/env.ts
@@ -71,9 +71,9 @@ export function getEnv(name: string): EnvConfig {
  *
  * @example
  *   const historical = cloneEnv(getEnv('mainnet'), {
- *     packages: { 'kai-leverage': { publishedAt: '0x...' } },
+ *     packages: { 'my-app': { publishedAt: '0x...' } },
  *   })
- *   createRebalanceReceipt(tx, typeArgs, args, { env: historical })
+ *   transfer(tx, typeArgs, args, { env: historical })
  */
 export function cloneEnv(
   base: EnvConfig,

--- a/ts/tests/gen/_framework/reified.ts
+++ b/ts/tests/gen/_framework/reified.ts
@@ -120,7 +120,7 @@ export type ToPhantomTypeArgument<T extends PhantomReified<PhantomTypeArgument>>
 export type PhantomTypeArgument = string
 
 export interface PhantomReified<P> {
-  phantomType: P
+  readonly phantomType: P
   kind: 'PhantomReified'
 }
 
@@ -135,8 +135,15 @@ export function phantom(type: string | Reified<TypeArgument, any>): PhantomReifi
       kind: 'PhantomReified',
     }
   } else {
+    // Reified handle case: read `fullTypeName` lazily so phantom handles created
+    // before `setActiveEnv(...)` still reflect the current env on each access.
+    // Without this getter, `phantomType` would freeze the typeName at phantom-call time
+    // and leak the wrong address into vector/option type-arg strings produced via
+    // `extractType(...)`.
     return {
-      phantomType: type.fullTypeName,
+      get phantomType() {
+        return type.fullTypeName
+      },
       kind: 'PhantomReified',
     }
   }

--- a/ts/tests/gen/examples/enums/structs.ts
+++ b/ts/tests/gen/examples/enums/structs.ts
@@ -87,9 +87,9 @@ export class Wrapped<T extends TypeArgument, U extends TypeArgument, V extends T
 {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::enums::Wrapped` = `${
-    getTypeOrigin('examples', 'enums::Wrapped')
-  }::enums::Wrapped` as const
+  static get $typeName(): `${string}::enums::Wrapped` {
+    return `${getTypeOrigin('examples', 'enums::Wrapped')}::enums::Wrapped` as const
+  }
   static readonly $numTypeParams = 3
   static readonly $isPhantom = [false, false, false] as const
 
@@ -138,18 +138,24 @@ export class Wrapped<T extends TypeArgument, U extends TypeArgument, V extends T
   ): WrappedReified<ToTypeArgument<T>, ToTypeArgument<U>, ToTypeArgument<V>> {
     const reifiedBcs = Wrapped.bcs(toBcs(T), toBcs(U), toBcs(V))
     return {
-      typeName: Wrapped.$typeName,
-      fullTypeName: composeSuiType(
-        Wrapped.$typeName,
-        ...[extractType(T), extractType(U), extractType(V)],
-      ) as `${string}::enums::Wrapped<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<
-        ToTypeArgument<U>
-      >}, ${ToTypeStr<ToTypeArgument<V>>}>`,
-      typeArgs: [extractType(T), extractType(U), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<T>>,
-        ToTypeStr<ToTypeArgument<U>>,
-        ToTypeStr<ToTypeArgument<V>>,
-      ],
+      get typeName() {
+        return Wrapped.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Wrapped.$typeName,
+          ...[extractType(T), extractType(U), extractType(V)],
+        ) as `${string}::enums::Wrapped<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<
+          ToTypeArgument<U>
+        >}, ${ToTypeStr<ToTypeArgument<V>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T), extractType(U), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<T>>,
+          ToTypeStr<ToTypeArgument<U>>,
+          ToTypeStr<ToTypeArgument<V>>,
+        ]
+      },
       isPhantom: Wrapped.$isPhantom,
       reifiedTypeArgs: [T, U, V],
       fromFields: (fields: Record<string, any>) => Wrapped.fromFields([T, U, V], fields),
@@ -461,9 +467,9 @@ export type ActionReified<T extends TypeArgument, U extends PhantomTypeArgument>
 >
 
 export class Action {
-  static readonly $typeName: string = `${
-    getTypeOrigin('examples', 'enums::Action')
-  }::enums::Action` as const
+  static get $typeName(): string {
+    return `${getTypeOrigin('examples', 'enums::Action')}::enums::Action` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, true] as const
 
@@ -476,15 +482,21 @@ export class Action {
   ): ActionReified<ToTypeArgument<T>, ToPhantomTypeArgument<U>> {
     const reifiedBcs = Action.bcs(toBcs(T))
     return {
-      typeName: Action.$typeName,
-      fullTypeName: composeSuiType(
-        Action.$typeName,
-        ...[extractType(T), extractType(U)],
-      ) as string,
-      typeArgs: [extractType(T), extractType(U)] as [
-        ToTypeStr<ToTypeArgument<T>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<U>>,
-      ],
+      get typeName() {
+        return Action.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Action.$typeName,
+          ...[extractType(T), extractType(U)],
+        ) as string
+      },
+      get typeArgs() {
+        return [extractType(T), extractType(U)] as [
+          ToTypeStr<ToTypeArgument<T>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<U>>,
+        ]
+      },
       isPhantom: Action.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => Action.fromFields([T, U], fields),
@@ -713,7 +725,9 @@ export class ActionStop<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName {
+    return Action.$typeName
+  }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Stop' as const
@@ -772,7 +786,9 @@ export class ActionPause<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName {
+    return Action.$typeName
+  }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Pause' as const
@@ -847,7 +863,9 @@ export class ActionJump<T extends TypeArgument, U extends PhantomTypeArgument>
 {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof Action.$typeName = Action.$typeName
+  static get $typeName(): typeof Action.$typeName {
+    return Action.$typeName
+  }
   static readonly $numTypeParams: typeof Action.$numTypeParams = Action.$numTypeParams
   static readonly $isPhantom: typeof Action.$isPhantom = Action.$isPhantom
   static readonly $variantName = 'Jump' as const

--- a/ts/tests/gen/examples/example-coin/structs.ts
+++ b/ts/tests/gen/examples/example-coin/structs.ts
@@ -51,9 +51,11 @@ export type EXAMPLE_COINJSON = {
 export class EXAMPLE_COIN implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::example_coin::EXAMPLE_COIN` = `${
-    getTypeOrigin('examples', 'example_coin::EXAMPLE_COIN')
-  }::example_coin::EXAMPLE_COIN` as const
+  static get $typeName(): `${string}::example_coin::EXAMPLE_COIN` {
+    return `${
+      getTypeOrigin('examples', 'example_coin::EXAMPLE_COIN')
+    }::example_coin::EXAMPLE_COIN` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -77,11 +79,15 @@ export class EXAMPLE_COIN implements StructClass {
   static reified(): EXAMPLE_COINReified {
     const reifiedBcs = EXAMPLE_COIN.bcs
     return {
-      typeName: EXAMPLE_COIN.$typeName,
-      fullTypeName: composeSuiType(
-        EXAMPLE_COIN.$typeName,
-        ...[],
-      ) as `${string}::example_coin::EXAMPLE_COIN`,
+      get typeName() {
+        return EXAMPLE_COIN.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          EXAMPLE_COIN.$typeName,
+          ...[],
+        ) as `${string}::example_coin::EXAMPLE_COIN`
+      },
       typeArgs: [] as [],
       isPhantom: EXAMPLE_COIN.$isPhantom,
       reifiedTypeArgs: [],
@@ -237,9 +243,9 @@ export type FaucetJSON = {
 export class Faucet implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::example_coin::Faucet` = `${
-    getTypeOrigin('examples', 'example_coin::Faucet')
-  }::example_coin::Faucet` as const
+  static get $typeName(): `${string}::example_coin::Faucet` {
+    return `${getTypeOrigin('examples', 'example_coin::Faucet')}::example_coin::Faucet` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -265,11 +271,15 @@ export class Faucet implements StructClass {
   static reified(): FaucetReified {
     const reifiedBcs = Faucet.bcs
     return {
-      typeName: Faucet.$typeName,
-      fullTypeName: composeSuiType(
-        Faucet.$typeName,
-        ...[],
-      ) as `${string}::example_coin::Faucet`,
+      get typeName() {
+        return Faucet.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Faucet.$typeName,
+          ...[],
+        ) as `${string}::example_coin::Faucet`
+      },
       typeArgs: [] as [],
       isPhantom: Faucet.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/examples/examples/structs.ts
+++ b/ts/tests/gen/examples/examples/structs.ts
@@ -54,9 +54,11 @@ export type ExampleStructJSON = {
 export class ExampleStruct implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::examples::ExampleStruct` = `${
-    getTypeOrigin('examples', 'examples::ExampleStruct')
-  }::examples::ExampleStruct` as const
+  static get $typeName(): `${string}::examples::ExampleStruct` {
+    return `${
+      getTypeOrigin('examples', 'examples::ExampleStruct')
+    }::examples::ExampleStruct` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -80,11 +82,15 @@ export class ExampleStruct implements StructClass {
   static reified(): ExampleStructReified {
     const reifiedBcs = ExampleStruct.bcs
     return {
-      typeName: ExampleStruct.$typeName,
-      fullTypeName: composeSuiType(
-        ExampleStruct.$typeName,
-        ...[],
-      ) as `${string}::examples::ExampleStruct`,
+      get typeName() {
+        return ExampleStruct.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ExampleStruct.$typeName,
+          ...[],
+        ) as `${string}::examples::ExampleStruct`
+      },
       typeArgs: [] as [],
       isPhantom: ExampleStruct.$isPhantom,
       reifiedTypeArgs: [],
@@ -255,9 +261,11 @@ export type SpecialTypesStructJSON = {
 export class SpecialTypesStruct implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::examples::SpecialTypesStruct` = `${
-    getTypeOrigin('examples', 'examples::SpecialTypesStruct')
-  }::examples::SpecialTypesStruct` as const
+  static get $typeName(): `${string}::examples::SpecialTypesStruct` {
+    return `${
+      getTypeOrigin('examples', 'examples::SpecialTypesStruct')
+    }::examples::SpecialTypesStruct` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -297,11 +305,15 @@ export class SpecialTypesStruct implements StructClass {
   static reified(): SpecialTypesStructReified {
     const reifiedBcs = SpecialTypesStruct.bcs
     return {
-      typeName: SpecialTypesStruct.$typeName,
-      fullTypeName: composeSuiType(
-        SpecialTypesStruct.$typeName,
-        ...[],
-      ) as `${string}::examples::SpecialTypesStruct`,
+      get typeName() {
+        return SpecialTypesStruct.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          SpecialTypesStruct.$typeName,
+          ...[],
+        ) as `${string}::examples::SpecialTypesStruct`
+      },
       typeArgs: [] as [],
       isPhantom: SpecialTypesStruct.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/examples/fixture/structs.ts
+++ b/ts/tests/gen/examples/fixture/structs.ts
@@ -69,9 +69,9 @@ export type DummyJSON = {
 export class Dummy implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Dummy` = `${
-    getTypeOrigin('examples', 'fixture::Dummy')
-  }::fixture::Dummy` as const
+  static get $typeName(): `${string}::fixture::Dummy` {
+    return `${getTypeOrigin('examples', 'fixture::Dummy')}::fixture::Dummy` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -95,11 +95,15 @@ export class Dummy implements StructClass {
   static reified(): DummyReified {
     const reifiedBcs = Dummy.bcs
     return {
-      typeName: Dummy.$typeName,
-      fullTypeName: composeSuiType(
-        Dummy.$typeName,
-        ...[],
-      ) as `${string}::fixture::Dummy`,
+      get typeName() {
+        return Dummy.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Dummy.$typeName,
+          ...[],
+        ) as `${string}::fixture::Dummy`
+      },
       typeArgs: [] as [],
       isPhantom: Dummy.$isPhantom,
       reifiedTypeArgs: [],
@@ -260,9 +264,11 @@ export type WithGenericFieldJSON<T extends TypeArgument> = {
 export class WithGenericField<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithGenericField` = `${
-    getTypeOrigin('examples', 'fixture::WithGenericField')
-  }::fixture::WithGenericField` as const
+  static get $typeName(): `${string}::fixture::WithGenericField` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithGenericField')
+    }::fixture::WithGenericField` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -290,12 +296,18 @@ export class WithGenericField<T extends TypeArgument> implements StructClass {
   ): WithGenericFieldReified<ToTypeArgument<T>> {
     const reifiedBcs = WithGenericField.bcs(toBcs(T))
     return {
-      typeName: WithGenericField.$typeName,
-      fullTypeName: composeSuiType(
-        WithGenericField.$typeName,
-        ...[extractType(T)],
-      ) as `${string}::fixture::WithGenericField<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return WithGenericField.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithGenericField.$typeName,
+          ...[extractType(T)],
+        ) as `${string}::fixture::WithGenericField<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: WithGenericField.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => WithGenericField.fromFields(T, fields),
@@ -521,9 +533,9 @@ export type BarJSON = {
 export class Bar implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Bar` = `${
-    getTypeOrigin('examples', 'fixture::Bar')
-  }::fixture::Bar` as const
+  static get $typeName(): `${string}::fixture::Bar` {
+    return `${getTypeOrigin('examples', 'fixture::Bar')}::fixture::Bar` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -547,11 +559,15 @@ export class Bar implements StructClass {
   static reified(): BarReified {
     const reifiedBcs = Bar.bcs
     return {
-      typeName: Bar.$typeName,
-      fullTypeName: composeSuiType(
-        Bar.$typeName,
-        ...[],
-      ) as `${string}::fixture::Bar`,
+      get typeName() {
+        return Bar.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Bar.$typeName,
+          ...[],
+        ) as `${string}::fixture::Bar`
+      },
       typeArgs: [] as [],
       isPhantom: Bar.$isPhantom,
       reifiedTypeArgs: [],
@@ -714,9 +730,11 @@ export class WithTwoGenerics<T extends TypeArgument, U extends TypeArgument>
 {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithTwoGenerics` = `${
-    getTypeOrigin('examples', 'fixture::WithTwoGenerics')
-  }::fixture::WithTwoGenerics` as const
+  static get $typeName(): `${string}::fixture::WithTwoGenerics` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithTwoGenerics')
+    }::fixture::WithTwoGenerics` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [false, false] as const
 
@@ -745,17 +763,23 @@ export class WithTwoGenerics<T extends TypeArgument, U extends TypeArgument>
   ): WithTwoGenericsReified<ToTypeArgument<T>, ToTypeArgument<U>> {
     const reifiedBcs = WithTwoGenerics.bcs(toBcs(T), toBcs(U))
     return {
-      typeName: WithTwoGenerics.$typeName,
-      fullTypeName: composeSuiType(
-        WithTwoGenerics.$typeName,
-        ...[extractType(T), extractType(U)],
-      ) as `${string}::fixture::WithTwoGenerics<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<
-        ToTypeArgument<U>
-      >}>`,
-      typeArgs: [extractType(T), extractType(U)] as [
-        ToTypeStr<ToTypeArgument<T>>,
-        ToTypeStr<ToTypeArgument<U>>,
-      ],
+      get typeName() {
+        return WithTwoGenerics.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithTwoGenerics.$typeName,
+          ...[extractType(T), extractType(U)],
+        ) as `${string}::fixture::WithTwoGenerics<${ToTypeStr<ToTypeArgument<T>>}, ${ToTypeStr<
+          ToTypeArgument<U>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T), extractType(U)] as [
+          ToTypeStr<ToTypeArgument<T>>,
+          ToTypeStr<ToTypeArgument<U>>,
+        ]
+      },
       isPhantom: WithTwoGenerics.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => WithTwoGenerics.fromFields([T, U], fields),
@@ -1022,9 +1046,9 @@ export type FooJSON<T extends TypeArgument> = {
 export class Foo<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::Foo` = `${
-    getTypeOrigin('examples', 'fixture::Foo')
-  }::fixture::Foo` as const
+  static get $typeName(): `${string}::fixture::Foo` {
+    return `${getTypeOrigin('examples', 'fixture::Foo')}::fixture::Foo` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -1078,12 +1102,18 @@ export class Foo<T extends TypeArgument> implements StructClass {
   ): FooReified<ToTypeArgument<T>> {
     const reifiedBcs = Foo.bcs(toBcs(T))
     return {
-      typeName: Foo.$typeName,
-      fullTypeName: composeSuiType(
-        Foo.$typeName,
-        ...[extractType(T)],
-      ) as `${string}::fixture::Foo<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return Foo.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Foo.$typeName,
+          ...[extractType(T)],
+        ) as `${string}::fixture::Foo<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: Foo.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Foo.fromFields(T, fields),
@@ -1487,9 +1517,11 @@ export class WithSpecialTypes<T extends PhantomTypeArgument, U extends TypeArgum
 {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypes` = `${
-    getTypeOrigin('examples', 'fixture::WithSpecialTypes')
-  }::fixture::WithSpecialTypes` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypes` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithSpecialTypes')
+    }::fixture::WithSpecialTypes` as const
+  }
   static readonly $numTypeParams = 2
   static readonly $isPhantom = [true, false] as const
 
@@ -1548,17 +1580,23 @@ export class WithSpecialTypes<T extends PhantomTypeArgument, U extends TypeArgum
   ): WithSpecialTypesReified<ToPhantomTypeArgument<T>, ToTypeArgument<U>> {
     const reifiedBcs = WithSpecialTypes.bcs(toBcs(U))
     return {
-      typeName: WithSpecialTypes.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypes.$typeName,
-        ...[extractType(T), extractType(U)],
-      ) as `${string}::fixture::WithSpecialTypes<${PhantomToTypeStr<
-        ToPhantomTypeArgument<T>
-      >}, ${ToTypeStr<ToTypeArgument<U>>}>`,
-      typeArgs: [extractType(T), extractType(U)] as [
-        PhantomToTypeStr<ToPhantomTypeArgument<T>>,
-        ToTypeStr<ToTypeArgument<U>>,
-      ],
+      get typeName() {
+        return WithSpecialTypes.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypes.$typeName,
+          ...[extractType(T), extractType(U)],
+        ) as `${string}::fixture::WithSpecialTypes<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}, ${ToTypeStr<ToTypeArgument<U>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T), extractType(U)] as [
+          PhantomToTypeStr<ToPhantomTypeArgument<T>>,
+          ToTypeStr<ToTypeArgument<U>>,
+        ]
+      },
       isPhantom: WithSpecialTypes.$isPhantom,
       reifiedTypeArgs: [T, U],
       fromFields: (fields: Record<string, any>) => WithSpecialTypes.fromFields([T, U], fields),
@@ -1967,9 +2005,11 @@ export class WithSpecialTypesAsGenerics<
 > implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypesAsGenerics` = `${
-    getTypeOrigin('examples', 'fixture::WithSpecialTypesAsGenerics')
-  }::fixture::WithSpecialTypesAsGenerics` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypesAsGenerics` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithSpecialTypesAsGenerics')
+    }::fixture::WithSpecialTypesAsGenerics` as const
+  }
   static readonly $numTypeParams = 8
   static readonly $isPhantom = [false, false, false, false, false, false, false, false] as const
 
@@ -2076,10 +2116,32 @@ export class WithSpecialTypesAsGenerics<
       toBcs(T7),
     )
     return {
-      typeName: WithSpecialTypesAsGenerics.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypesAsGenerics.$typeName,
-        ...[
+      get typeName() {
+        return WithSpecialTypesAsGenerics.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypesAsGenerics.$typeName,
+          ...[
+            extractType(T0),
+            extractType(T1),
+            extractType(T2),
+            extractType(T3),
+            extractType(T4),
+            extractType(T5),
+            extractType(T6),
+            extractType(T7),
+          ],
+        ) as `${string}::fixture::WithSpecialTypesAsGenerics<${ToTypeStr<
+          ToTypeArgument<T0>
+        >}, ${ToTypeStr<ToTypeArgument<T1>>}, ${ToTypeStr<ToTypeArgument<T2>>}, ${ToTypeStr<
+          ToTypeArgument<T3>
+        >}, ${ToTypeStr<ToTypeArgument<T4>>}, ${ToTypeStr<ToTypeArgument<T5>>}, ${ToTypeStr<
+          ToTypeArgument<T6>
+        >}, ${ToTypeStr<ToTypeArgument<T7>>}>`
+      },
+      get typeArgs() {
+        return [
           extractType(T0),
           extractType(T1),
           extractType(T2),
@@ -2088,33 +2150,17 @@ export class WithSpecialTypesAsGenerics<
           extractType(T5),
           extractType(T6),
           extractType(T7),
-        ],
-      ) as `${string}::fixture::WithSpecialTypesAsGenerics<${ToTypeStr<
-        ToTypeArgument<T0>
-      >}, ${ToTypeStr<ToTypeArgument<T1>>}, ${ToTypeStr<ToTypeArgument<T2>>}, ${ToTypeStr<
-        ToTypeArgument<T3>
-      >}, ${ToTypeStr<ToTypeArgument<T4>>}, ${ToTypeStr<ToTypeArgument<T5>>}, ${ToTypeStr<
-        ToTypeArgument<T6>
-      >}, ${ToTypeStr<ToTypeArgument<T7>>}>`,
-      typeArgs: [
-        extractType(T0),
-        extractType(T1),
-        extractType(T2),
-        extractType(T3),
-        extractType(T4),
-        extractType(T5),
-        extractType(T6),
-        extractType(T7),
-      ] as [
-        ToTypeStr<ToTypeArgument<T0>>,
-        ToTypeStr<ToTypeArgument<T1>>,
-        ToTypeStr<ToTypeArgument<T2>>,
-        ToTypeStr<ToTypeArgument<T3>>,
-        ToTypeStr<ToTypeArgument<T4>>,
-        ToTypeStr<ToTypeArgument<T5>>,
-        ToTypeStr<ToTypeArgument<T6>>,
-        ToTypeStr<ToTypeArgument<T7>>,
-      ],
+        ] as [
+          ToTypeStr<ToTypeArgument<T0>>,
+          ToTypeStr<ToTypeArgument<T1>>,
+          ToTypeStr<ToTypeArgument<T2>>,
+          ToTypeStr<ToTypeArgument<T3>>,
+          ToTypeStr<ToTypeArgument<T4>>,
+          ToTypeStr<ToTypeArgument<T5>>,
+          ToTypeStr<ToTypeArgument<T6>>,
+          ToTypeStr<ToTypeArgument<T7>>,
+        ]
+      },
       isPhantom: WithSpecialTypesAsGenerics.$isPhantom,
       reifiedTypeArgs: [T0, T1, T2, T3, T4, T5, T6, T7],
       fromFields: (fields: Record<string, any>) =>
@@ -2652,9 +2698,11 @@ export type WithSpecialTypesInVectorsJSON<T extends TypeArgument> = {
 export class WithSpecialTypesInVectors<T extends TypeArgument> implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::fixture::WithSpecialTypesInVectors` = `${
-    getTypeOrigin('examples', 'fixture::WithSpecialTypesInVectors')
-  }::fixture::WithSpecialTypesInVectors` as const
+  static get $typeName(): `${string}::fixture::WithSpecialTypesInVectors` {
+    return `${
+      getTypeOrigin('examples', 'fixture::WithSpecialTypesInVectors')
+    }::fixture::WithSpecialTypesInVectors` as const
+  }
   static readonly $numTypeParams = 1
   static readonly $isPhantom = [false] as const
 
@@ -2694,12 +2742,18 @@ export class WithSpecialTypesInVectors<T extends TypeArgument> implements Struct
   ): WithSpecialTypesInVectorsReified<ToTypeArgument<T>> {
     const reifiedBcs = WithSpecialTypesInVectors.bcs(toBcs(T))
     return {
-      typeName: WithSpecialTypesInVectors.$typeName,
-      fullTypeName: composeSuiType(
-        WithSpecialTypesInVectors.$typeName,
-        ...[extractType(T)],
-      ) as `${string}::fixture::WithSpecialTypesInVectors<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return WithSpecialTypesInVectors.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          WithSpecialTypesInVectors.$typeName,
+          ...[extractType(T)],
+        ) as `${string}::fixture::WithSpecialTypesInVectors<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: WithSpecialTypesInVectors.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => WithSpecialTypesInVectors.fromFields(T, fields),

--- a/ts/tests/gen/examples/other-module/structs.ts
+++ b/ts/tests/gen/examples/other-module/structs.ts
@@ -53,9 +53,11 @@ export type StructFromOtherModuleJSON = {
 export class StructFromOtherModule implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::other_module::StructFromOtherModule` = `${
-    getTypeOrigin('examples', 'other_module::StructFromOtherModule')
-  }::other_module::StructFromOtherModule` as const
+  static get $typeName(): `${string}::other_module::StructFromOtherModule` {
+    return `${
+      getTypeOrigin('examples', 'other_module::StructFromOtherModule')
+    }::other_module::StructFromOtherModule` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -79,11 +81,15 @@ export class StructFromOtherModule implements StructClass {
   static reified(): StructFromOtherModuleReified {
     const reifiedBcs = StructFromOtherModule.bcs
     return {
-      typeName: StructFromOtherModule.$typeName,
-      fullTypeName: composeSuiType(
-        StructFromOtherModule.$typeName,
-        ...[],
-      ) as `${string}::other_module::StructFromOtherModule`,
+      get typeName() {
+        return StructFromOtherModule.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          StructFromOtherModule.$typeName,
+          ...[],
+        ) as `${string}::other_module::StructFromOtherModule`
+      },
       typeArgs: [] as [],
       isPhantom: StructFromOtherModule.$isPhantom,
       reifiedTypeArgs: [],
@@ -246,9 +252,11 @@ export type AddedInAnUpgradeJSON = {
 export class AddedInAnUpgrade implements StructClass {
   __StructClass = true as const
 
-  static readonly $typeName: `${string}::other_module::AddedInAnUpgrade` = `${
-    getTypeOrigin('examples', 'other_module::AddedInAnUpgrade')
-  }::other_module::AddedInAnUpgrade` as const
+  static get $typeName(): `${string}::other_module::AddedInAnUpgrade` {
+    return `${
+      getTypeOrigin('examples', 'other_module::AddedInAnUpgrade')
+    }::other_module::AddedInAnUpgrade` as const
+  }
   static readonly $numTypeParams = 0
   static readonly $isPhantom = [] as const
 
@@ -272,11 +280,15 @@ export class AddedInAnUpgrade implements StructClass {
   static reified(): AddedInAnUpgradeReified {
     const reifiedBcs = AddedInAnUpgrade.bcs
     return {
-      typeName: AddedInAnUpgrade.$typeName,
-      fullTypeName: composeSuiType(
-        AddedInAnUpgrade.$typeName,
-        ...[],
-      ) as `${string}::other_module::AddedInAnUpgrade`,
+      get typeName() {
+        return AddedInAnUpgrade.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AddedInAnUpgrade.$typeName,
+          ...[],
+        ) as `${string}::other_module::AddedInAnUpgrade`
+      },
       typeArgs: [] as [],
       isPhantom: AddedInAnUpgrade.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/std/ascii/structs.ts
+++ b/ts/tests/gen/std/ascii/structs.ts
@@ -85,11 +85,15 @@ export class String implements StructClass {
   static reified(): StringReified {
     const reifiedBcs = String.bcs
     return {
-      typeName: String.$typeName,
-      fullTypeName: composeSuiType(
-        String.$typeName,
-        ...[],
-      ) as `0x1::ascii::String`,
+      get typeName() {
+        return String.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          String.$typeName,
+          ...[],
+        ) as `0x1::ascii::String`
+      },
       typeArgs: [] as [],
       isPhantom: String.$isPhantom,
       reifiedTypeArgs: [],
@@ -268,11 +272,15 @@ export class Char implements StructClass {
   static reified(): CharReified {
     const reifiedBcs = Char.bcs
     return {
-      typeName: Char.$typeName,
-      fullTypeName: composeSuiType(
-        Char.$typeName,
-        ...[],
-      ) as `0x1::ascii::Char`,
+      get typeName() {
+        return Char.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Char.$typeName,
+          ...[],
+        ) as `0x1::ascii::Char`
+      },
       typeArgs: [] as [],
       isPhantom: Char.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/std/bit-vector/structs.ts
+++ b/ts/tests/gen/std/bit-vector/structs.ts
@@ -77,11 +77,15 @@ export class BitVector implements StructClass {
   static reified(): BitVectorReified {
     const reifiedBcs = BitVector.bcs
     return {
-      typeName: BitVector.$typeName,
-      fullTypeName: composeSuiType(
-        BitVector.$typeName,
-        ...[],
-      ) as `0x1::bit_vector::BitVector`,
+      get typeName() {
+        return BitVector.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          BitVector.$typeName,
+          ...[],
+        ) as `0x1::bit_vector::BitVector`
+      },
       typeArgs: [] as [],
       isPhantom: BitVector.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/std/fixed-point32/structs.ts
+++ b/ts/tests/gen/std/fixed-point32/structs.ts
@@ -87,11 +87,15 @@ export class FixedPoint32 implements StructClass {
   static reified(): FixedPoint32Reified {
     const reifiedBcs = FixedPoint32.bcs
     return {
-      typeName: FixedPoint32.$typeName,
-      fullTypeName: composeSuiType(
-        FixedPoint32.$typeName,
-        ...[],
-      ) as `0x1::fixed_point32::FixedPoint32`,
+      get typeName() {
+        return FixedPoint32.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          FixedPoint32.$typeName,
+          ...[],
+        ) as `0x1::fixed_point32::FixedPoint32`
+      },
       typeArgs: [] as [],
       isPhantom: FixedPoint32.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/std/internal/structs.ts
+++ b/ts/tests/gen/std/internal/structs.ts
@@ -112,12 +112,18 @@ export class Permit<T extends PhantomTypeArgument> implements StructClass {
   ): PermitReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Permit.bcs
     return {
-      typeName: Permit.$typeName,
-      fullTypeName: composeSuiType(
-        Permit.$typeName,
-        ...[extractType(T)],
-      ) as `0x1::internal::Permit<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Permit.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Permit.$typeName,
+          ...[extractType(T)],
+        ) as `0x1::internal::Permit<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Permit.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Permit.fromFields(T, fields),

--- a/ts/tests/gen/std/option/structs.ts
+++ b/ts/tests/gen/std/option/structs.ts
@@ -93,12 +93,18 @@ export class Option<Element extends TypeArgument> implements StructClass {
   ): OptionReified<ToTypeArgument<Element>> {
     const reifiedBcs = Option.bcs(toBcs(Element))
     return {
-      typeName: Option.$typeName,
-      fullTypeName: composeSuiType(
-        Option.$typeName,
-        ...[extractType(Element)],
-      ) as `0x1::option::Option<${ToTypeStr<ToTypeArgument<Element>>}>`,
-      typeArgs: [extractType(Element)] as [ToTypeStr<ToTypeArgument<Element>>],
+      get typeName() {
+        return Option.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Option.$typeName,
+          ...[extractType(Element)],
+        ) as `0x1::option::Option<${ToTypeStr<ToTypeArgument<Element>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Element)] as [ToTypeStr<ToTypeArgument<Element>>]
+      },
       isPhantom: Option.$isPhantom,
       reifiedTypeArgs: [Element],
       fromFields: (fields: Record<string, any>) => Option.fromFields(Element, fields),

--- a/ts/tests/gen/std/string/structs.ts
+++ b/ts/tests/gen/std/string/structs.ts
@@ -82,11 +82,15 @@ export class String implements StructClass {
   static reified(): StringReified {
     const reifiedBcs = String.bcs
     return {
-      typeName: String.$typeName,
-      fullTypeName: composeSuiType(
-        String.$typeName,
-        ...[],
-      ) as `0x1::string::String`,
+      get typeName() {
+        return String.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          String.$typeName,
+          ...[],
+        ) as `0x1::string::String`
+      },
       typeArgs: [] as [],
       isPhantom: String.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/std/type-name/structs.ts
+++ b/ts/tests/gen/std/type-name/structs.ts
@@ -91,11 +91,15 @@ export class TypeName implements StructClass {
   static reified(): TypeNameReified {
     const reifiedBcs = TypeName.bcs
     return {
-      typeName: TypeName.$typeName,
-      fullTypeName: composeSuiType(
-        TypeName.$typeName,
-        ...[],
-      ) as `0x1::type_name::TypeName`,
+      get typeName() {
+        return TypeName.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TypeName.$typeName,
+          ...[],
+        ) as `0x1::type_name::TypeName`
+      },
       typeArgs: [] as [],
       isPhantom: TypeName.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/std/uq32-32/structs.ts
+++ b/ts/tests/gen/std/uq32-32/structs.ts
@@ -85,11 +85,15 @@ export class UQ32_32 implements StructClass {
   static reified(): UQ32_32Reified {
     const reifiedBcs = UQ32_32.bcs
     return {
-      typeName: UQ32_32.$typeName,
-      fullTypeName: composeSuiType(
-        UQ32_32.$typeName,
-        ...[],
-      ) as `0x1::uq32_32::UQ32_32`,
+      get typeName() {
+        return UQ32_32.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UQ32_32.$typeName,
+          ...[],
+        ) as `0x1::uq32_32::UQ32_32`
+      },
       typeArgs: [] as [],
       isPhantom: UQ32_32.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/std/uq64-64/structs.ts
+++ b/ts/tests/gen/std/uq64-64/structs.ts
@@ -85,11 +85,15 @@ export class UQ64_64 implements StructClass {
   static reified(): UQ64_64Reified {
     const reifiedBcs = UQ64_64.bcs
     return {
-      typeName: UQ64_64.$typeName,
-      fullTypeName: composeSuiType(
-        UQ64_64.$typeName,
-        ...[],
-      ) as `0x1::uq64_64::UQ64_64`,
+      get typeName() {
+        return UQ64_64.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UQ64_64.$typeName,
+          ...[],
+        ) as `0x1::uq64_64::UQ64_64`
+      },
       typeArgs: [] as [],
       isPhantom: UQ64_64.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/accumulator-metadata/structs.ts
+++ b/ts/tests/gen/sui/accumulator-metadata/structs.ts
@@ -91,11 +91,15 @@ export class OwnerKey implements StructClass {
   static reified(): OwnerKeyReified {
     const reifiedBcs = OwnerKey.bcs
     return {
-      typeName: OwnerKey.$typeName,
-      fullTypeName: composeSuiType(
-        OwnerKey.$typeName,
-        ...[],
-      ) as `0x2::accumulator_metadata::OwnerKey`,
+      get typeName() {
+        return OwnerKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          OwnerKey.$typeName,
+          ...[],
+        ) as `0x2::accumulator_metadata::OwnerKey`
+      },
       typeArgs: [] as [],
       isPhantom: OwnerKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -287,11 +291,15 @@ export class Owner implements StructClass {
   static reified(): OwnerReified {
     const reifiedBcs = Owner.bcs
     return {
-      typeName: Owner.$typeName,
-      fullTypeName: composeSuiType(
-        Owner.$typeName,
-        ...[],
-      ) as `0x2::accumulator_metadata::Owner`,
+      get typeName() {
+        return Owner.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Owner.$typeName,
+          ...[],
+        ) as `0x2::accumulator_metadata::Owner`
+      },
       typeArgs: [] as [],
       isPhantom: Owner.$isPhantom,
       reifiedTypeArgs: [],
@@ -483,12 +491,18 @@ export class MetadataKey<T extends PhantomTypeArgument> implements StructClass {
   ): MetadataKeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = MetadataKey.bcs
     return {
-      typeName: MetadataKey.$typeName,
-      fullTypeName: composeSuiType(
-        MetadataKey.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::accumulator_metadata::MetadataKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return MetadataKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          MetadataKey.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::accumulator_metadata::MetadataKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: MetadataKey.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => MetadataKey.fromFields(T, fields),
@@ -736,12 +750,18 @@ export class Metadata<T extends PhantomTypeArgument> implements StructClass {
   ): MetadataReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Metadata.bcs
     return {
-      typeName: Metadata.$typeName,
-      fullTypeName: composeSuiType(
-        Metadata.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::accumulator_metadata::Metadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Metadata.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Metadata.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::accumulator_metadata::Metadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Metadata.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Metadata.fromFields(T, fields),

--- a/ts/tests/gen/sui/accumulator-settlement/structs.ts
+++ b/ts/tests/gen/sui/accumulator-settlement/structs.ts
@@ -88,11 +88,15 @@ export class EventStreamHead implements StructClass {
   static reified(): EventStreamHeadReified {
     const reifiedBcs = EventStreamHead.bcs
     return {
-      typeName: EventStreamHead.$typeName,
-      fullTypeName: composeSuiType(
-        EventStreamHead.$typeName,
-        ...[],
-      ) as `0x2::accumulator_settlement::EventStreamHead`,
+      get typeName() {
+        return EventStreamHead.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          EventStreamHead.$typeName,
+          ...[],
+        ) as `0x2::accumulator_settlement::EventStreamHead`
+      },
       typeArgs: [] as [],
       isPhantom: EventStreamHead.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/accumulator/structs.ts
+++ b/ts/tests/gen/sui/accumulator/structs.ts
@@ -79,11 +79,15 @@ export class AccumulatorRoot implements StructClass {
   static reified(): AccumulatorRootReified {
     const reifiedBcs = AccumulatorRoot.bcs
     return {
-      typeName: AccumulatorRoot.$typeName,
-      fullTypeName: composeSuiType(
-        AccumulatorRoot.$typeName,
-        ...[],
-      ) as `0x2::accumulator::AccumulatorRoot`,
+      get typeName() {
+        return AccumulatorRoot.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AccumulatorRoot.$typeName,
+          ...[],
+        ) as `0x2::accumulator::AccumulatorRoot`
+      },
       typeArgs: [] as [],
       isPhantom: AccumulatorRoot.$isPhantom,
       reifiedTypeArgs: [],
@@ -268,11 +272,15 @@ export class U128 implements StructClass {
   static reified(): U128Reified {
     const reifiedBcs = U128.bcs
     return {
-      typeName: U128.$typeName,
-      fullTypeName: composeSuiType(
-        U128.$typeName,
-        ...[],
-      ) as `0x2::accumulator::U128`,
+      get typeName() {
+        return U128.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          U128.$typeName,
+          ...[],
+        ) as `0x2::accumulator::U128`
+      },
       typeArgs: [] as [],
       isPhantom: U128.$isPhantom,
       reifiedTypeArgs: [],
@@ -456,12 +464,18 @@ export class Key<T extends PhantomTypeArgument> implements StructClass {
   ): KeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Key.bcs
     return {
-      typeName: Key.$typeName,
-      fullTypeName: composeSuiType(
-        Key.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::accumulator::Key<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Key.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Key.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::accumulator::Key<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Key.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Key.fromFields(T, fields),

--- a/ts/tests/gen/sui/authenticator-state/structs.ts
+++ b/ts/tests/gen/sui/authenticator-state/structs.ts
@@ -85,11 +85,15 @@ export class AuthenticatorState implements StructClass {
   static reified(): AuthenticatorStateReified {
     const reifiedBcs = AuthenticatorState.bcs
     return {
-      typeName: AuthenticatorState.$typeName,
-      fullTypeName: composeSuiType(
-        AuthenticatorState.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::AuthenticatorState`,
+      get typeName() {
+        return AuthenticatorState.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AuthenticatorState.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::AuthenticatorState`
+      },
       typeArgs: [] as [],
       isPhantom: AuthenticatorState.$isPhantom,
       reifiedTypeArgs: [],
@@ -283,11 +287,15 @@ export class AuthenticatorStateInner implements StructClass {
   static reified(): AuthenticatorStateInnerReified {
     const reifiedBcs = AuthenticatorStateInner.bcs
     return {
-      typeName: AuthenticatorStateInner.$typeName,
-      fullTypeName: composeSuiType(
-        AuthenticatorStateInner.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::AuthenticatorStateInner`,
+      get typeName() {
+        return AuthenticatorStateInner.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AuthenticatorStateInner.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::AuthenticatorStateInner`
+      },
       typeArgs: [] as [],
       isPhantom: AuthenticatorStateInner.$isPhantom,
       reifiedTypeArgs: [],
@@ -490,11 +498,15 @@ export class JWK implements StructClass {
   static reified(): JWKReified {
     const reifiedBcs = JWK.bcs
     return {
-      typeName: JWK.$typeName,
-      fullTypeName: composeSuiType(
-        JWK.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::JWK`,
+      get typeName() {
+        return JWK.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          JWK.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::JWK`
+      },
       typeArgs: [] as [],
       isPhantom: JWK.$isPhantom,
       reifiedTypeArgs: [],
@@ -693,11 +705,15 @@ export class JwkId implements StructClass {
   static reified(): JwkIdReified {
     const reifiedBcs = JwkId.bcs
     return {
-      typeName: JwkId.$typeName,
-      fullTypeName: composeSuiType(
-        JwkId.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::JwkId`,
+      get typeName() {
+        return JwkId.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          JwkId.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::JwkId`
+      },
       typeArgs: [] as [],
       isPhantom: JwkId.$isPhantom,
       reifiedTypeArgs: [],
@@ -889,11 +905,15 @@ export class ActiveJwk implements StructClass {
   static reified(): ActiveJwkReified {
     const reifiedBcs = ActiveJwk.bcs
     return {
-      typeName: ActiveJwk.$typeName,
-      fullTypeName: composeSuiType(
-        ActiveJwk.$typeName,
-        ...[],
-      ) as `0x2::authenticator_state::ActiveJwk`,
+      get typeName() {
+        return ActiveJwk.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ActiveJwk.$typeName,
+          ...[],
+        ) as `0x2::authenticator_state::ActiveJwk`
+      },
       typeArgs: [] as [],
       isPhantom: ActiveJwk.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/bag/structs.ts
+++ b/ts/tests/gen/sui/bag/structs.ts
@@ -102,11 +102,15 @@ export class Bag implements StructClass {
   static reified(): BagReified {
     const reifiedBcs = Bag.bcs
     return {
-      typeName: Bag.$typeName,
-      fullTypeName: composeSuiType(
-        Bag.$typeName,
-        ...[],
-      ) as `0x2::bag::Bag`,
+      get typeName() {
+        return Bag.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Bag.$typeName,
+          ...[],
+        ) as `0x2::bag::Bag`
+      },
       typeArgs: [] as [],
       isPhantom: Bag.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/balance/structs.ts
+++ b/ts/tests/gen/sui/balance/structs.ts
@@ -89,12 +89,18 @@ export class Supply<T extends PhantomTypeArgument> implements StructClass {
   ): SupplyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Supply.bcs
     return {
-      typeName: Supply.$typeName,
-      fullTypeName: composeSuiType(
-        Supply.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::balance::Supply<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Supply.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Supply.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::balance::Supply<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Supply.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Supply.fromFields(T, fields),
@@ -342,12 +348,18 @@ export class Balance<T extends PhantomTypeArgument> implements StructClass {
   ): BalanceReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Balance.bcs
     return {
-      typeName: Balance.$typeName,
-      fullTypeName: composeSuiType(
-        Balance.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::balance::Balance<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Balance.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Balance.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::balance::Balance<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Balance.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Balance.fromFields(T, fields),

--- a/ts/tests/gen/sui/bcs/structs.ts
+++ b/ts/tests/gen/sui/bcs/structs.ts
@@ -112,11 +112,15 @@ export class BCS implements StructClass {
   static reified(): BCSReified {
     const reifiedBcs = BCS.bcs
     return {
-      typeName: BCS.$typeName,
-      fullTypeName: composeSuiType(
-        BCS.$typeName,
-        ...[],
-      ) as `0x2::bcs::BCS`,
+      get typeName() {
+        return BCS.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          BCS.$typeName,
+          ...[],
+        ) as `0x2::bcs::BCS`
+      },
       typeArgs: [] as [],
       isPhantom: BCS.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/bls12381/structs.ts
+++ b/ts/tests/gen/sui/bls12381/structs.ts
@@ -72,11 +72,15 @@ export class Scalar implements StructClass {
   static reified(): ScalarReified {
     const reifiedBcs = Scalar.bcs
     return {
-      typeName: Scalar.$typeName,
-      fullTypeName: composeSuiType(
-        Scalar.$typeName,
-        ...[],
-      ) as `0x2::bls12381::Scalar`,
+      get typeName() {
+        return Scalar.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Scalar.$typeName,
+          ...[],
+        ) as `0x2::bls12381::Scalar`
+      },
       typeArgs: [] as [],
       isPhantom: Scalar.$isPhantom,
       reifiedTypeArgs: [],
@@ -254,11 +258,15 @@ export class G1 implements StructClass {
   static reified(): G1Reified {
     const reifiedBcs = G1.bcs
     return {
-      typeName: G1.$typeName,
-      fullTypeName: composeSuiType(
-        G1.$typeName,
-        ...[],
-      ) as `0x2::bls12381::G1`,
+      get typeName() {
+        return G1.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          G1.$typeName,
+          ...[],
+        ) as `0x2::bls12381::G1`
+      },
       typeArgs: [] as [],
       isPhantom: G1.$isPhantom,
       reifiedTypeArgs: [],
@@ -436,11 +444,15 @@ export class G2 implements StructClass {
   static reified(): G2Reified {
     const reifiedBcs = G2.bcs
     return {
-      typeName: G2.$typeName,
-      fullTypeName: composeSuiType(
-        G2.$typeName,
-        ...[],
-      ) as `0x2::bls12381::G2`,
+      get typeName() {
+        return G2.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          G2.$typeName,
+          ...[],
+        ) as `0x2::bls12381::G2`
+      },
       typeArgs: [] as [],
       isPhantom: G2.$isPhantom,
       reifiedTypeArgs: [],
@@ -618,11 +630,15 @@ export class GT implements StructClass {
   static reified(): GTReified {
     const reifiedBcs = GT.bcs
     return {
-      typeName: GT.$typeName,
-      fullTypeName: composeSuiType(
-        GT.$typeName,
-        ...[],
-      ) as `0x2::bls12381::GT`,
+      get typeName() {
+        return GT.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          GT.$typeName,
+          ...[],
+        ) as `0x2::bls12381::GT`
+      },
       typeArgs: [] as [],
       isPhantom: GT.$isPhantom,
       reifiedTypeArgs: [],
@@ -801,11 +817,15 @@ export class UncompressedG1 implements StructClass {
   static reified(): UncompressedG1Reified {
     const reifiedBcs = UncompressedG1.bcs
     return {
-      typeName: UncompressedG1.$typeName,
-      fullTypeName: composeSuiType(
-        UncompressedG1.$typeName,
-        ...[],
-      ) as `0x2::bls12381::UncompressedG1`,
+      get typeName() {
+        return UncompressedG1.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UncompressedG1.$typeName,
+          ...[],
+        ) as `0x2::bls12381::UncompressedG1`
+      },
       typeArgs: [] as [],
       isPhantom: UncompressedG1.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/borrow/structs.ts
+++ b/ts/tests/gen/sui/borrow/structs.ts
@@ -95,12 +95,18 @@ export class Referent<T extends TypeArgument> implements StructClass {
   ): ReferentReified<ToTypeArgument<T>> {
     const reifiedBcs = Referent.bcs(toBcs(T))
     return {
-      typeName: Referent.$typeName,
-      fullTypeName: composeSuiType(
-        Referent.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::borrow::Referent<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return Referent.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Referent.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::borrow::Referent<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: Referent.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Referent.fromFields(T, fields),
@@ -357,11 +363,15 @@ export class Borrow implements StructClass {
   static reified(): BorrowReified {
     const reifiedBcs = Borrow.bcs
     return {
-      typeName: Borrow.$typeName,
-      fullTypeName: composeSuiType(
-        Borrow.$typeName,
-        ...[],
-      ) as `0x2::borrow::Borrow`,
+      get typeName() {
+        return Borrow.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Borrow.$typeName,
+          ...[],
+        ) as `0x2::borrow::Borrow`
+      },
       typeArgs: [] as [],
       isPhantom: Borrow.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/clock/structs.ts
+++ b/ts/tests/gen/sui/clock/structs.ts
@@ -102,11 +102,15 @@ export class Clock implements StructClass {
   static reified(): ClockReified {
     const reifiedBcs = Clock.bcs
     return {
-      typeName: Clock.$typeName,
-      fullTypeName: composeSuiType(
-        Clock.$typeName,
-        ...[],
-      ) as `0x2::clock::Clock`,
+      get typeName() {
+        return Clock.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Clock.$typeName,
+          ...[],
+        ) as `0x2::clock::Clock`
+      },
       typeArgs: [] as [],
       isPhantom: Clock.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/coin-registry/structs.ts
+++ b/ts/tests/gen/sui/coin-registry/structs.ts
@@ -101,11 +101,15 @@ export class CoinRegistry implements StructClass {
   static reified(): CoinRegistryReified {
     const reifiedBcs = CoinRegistry.bcs
     return {
-      typeName: CoinRegistry.$typeName,
-      fullTypeName: composeSuiType(
-        CoinRegistry.$typeName,
-        ...[],
-      ) as `0x2::coin_registry::CoinRegistry`,
+      get typeName() {
+        return CoinRegistry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CoinRegistry.$typeName,
+          ...[],
+        ) as `0x2::coin_registry::CoinRegistry`
+      },
       typeArgs: [] as [],
       isPhantom: CoinRegistry.$isPhantom,
       reifiedTypeArgs: [],
@@ -293,11 +297,15 @@ export class ExtraField implements StructClass {
   static reified(): ExtraFieldReified {
     const reifiedBcs = ExtraField.bcs
     return {
-      typeName: ExtraField.$typeName,
-      fullTypeName: composeSuiType(
-        ExtraField.$typeName,
-        ...[],
-      ) as `0x2::coin_registry::ExtraField`,
+      get typeName() {
+        return ExtraField.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ExtraField.$typeName,
+          ...[],
+        ) as `0x2::coin_registry::ExtraField`
+      },
       typeArgs: [] as [],
       isPhantom: ExtraField.$isPhantom,
       reifiedTypeArgs: [],
@@ -487,12 +495,18 @@ export class CurrencyKey<T extends PhantomTypeArgument> implements StructClass {
   ): CurrencyKeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = CurrencyKey.bcs
     return {
-      typeName: CurrencyKey.$typeName,
-      fullTypeName: composeSuiType(
-        CurrencyKey.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::CurrencyKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return CurrencyKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CurrencyKey.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::CurrencyKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: CurrencyKey.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => CurrencyKey.fromFields(T, fields),
@@ -736,11 +750,15 @@ export class LegacyMetadataKey implements StructClass {
   static reified(): LegacyMetadataKeyReified {
     const reifiedBcs = LegacyMetadataKey.bcs
     return {
-      typeName: LegacyMetadataKey.$typeName,
-      fullTypeName: composeSuiType(
-        LegacyMetadataKey.$typeName,
-        ...[],
-      ) as `0x2::coin_registry::LegacyMetadataKey`,
+      get typeName() {
+        return LegacyMetadataKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          LegacyMetadataKey.$typeName,
+          ...[],
+        ) as `0x2::coin_registry::LegacyMetadataKey`
+      },
       typeArgs: [] as [],
       isPhantom: LegacyMetadataKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -929,12 +947,18 @@ export class MetadataCap<T extends PhantomTypeArgument> implements StructClass {
   ): MetadataCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = MetadataCap.bcs
     return {
-      typeName: MetadataCap.$typeName,
-      fullTypeName: composeSuiType(
-        MetadataCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::MetadataCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return MetadataCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          MetadataCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::MetadataCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: MetadataCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => MetadataCap.fromFields(T, fields),
@@ -1179,12 +1203,18 @@ export class Borrow<T extends PhantomTypeArgument> implements StructClass {
   ): BorrowReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Borrow.bcs
     return {
-      typeName: Borrow.$typeName,
-      fullTypeName: composeSuiType(
-        Borrow.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::Borrow<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Borrow.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Borrow.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::Borrow<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Borrow.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Borrow.fromFields(T, fields),
@@ -1501,12 +1531,18 @@ export class Currency<T extends PhantomTypeArgument> implements StructClass {
   ): CurrencyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Currency.bcs
     return {
-      typeName: Currency.$typeName,
-      fullTypeName: composeSuiType(
-        Currency.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::Currency<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Currency.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Currency.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::Currency<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Currency.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Currency.fromFields(T, fields),
@@ -1842,12 +1878,20 @@ export class CurrencyInitializer<T extends PhantomTypeArgument> implements Struc
   ): CurrencyInitializerReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = CurrencyInitializer.bcs
     return {
-      typeName: CurrencyInitializer.$typeName,
-      fullTypeName: composeSuiType(
-        CurrencyInitializer.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::CurrencyInitializer<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return CurrencyInitializer.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CurrencyInitializer.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::CurrencyInitializer<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: CurrencyInitializer.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => CurrencyInitializer.fromFields(T, fields),
@@ -2105,12 +2149,18 @@ export class SupplyState {
   ): SupplyStateReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = SupplyState.bcs
     return {
-      typeName: SupplyState.$typeName,
-      fullTypeName: composeSuiType(
-        SupplyState.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin_registry::SupplyState<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return SupplyState.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          SupplyState.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin_registry::SupplyState<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: SupplyState.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => SupplyState.fromFields([T], fields),
@@ -2295,7 +2345,9 @@ export type SupplyStateFixedJSON<T extends PhantomTypeArgument> = {
 export class SupplyStateFixed<T extends PhantomTypeArgument> implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof SupplyState.$typeName = SupplyState.$typeName
+  static get $typeName(): typeof SupplyState.$typeName {
+    return SupplyState.$typeName
+  }
   static readonly $numTypeParams: typeof SupplyState.$numTypeParams = SupplyState.$numTypeParams
   static readonly $isPhantom: typeof SupplyState.$isPhantom = SupplyState.$isPhantom
   static readonly $variantName = 'Fixed' as const
@@ -2356,7 +2408,9 @@ export type SupplyStateBurnOnlyJSON<T extends PhantomTypeArgument> = {
 export class SupplyStateBurnOnly<T extends PhantomTypeArgument> implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof SupplyState.$typeName = SupplyState.$typeName
+  static get $typeName(): typeof SupplyState.$typeName {
+    return SupplyState.$typeName
+  }
   static readonly $numTypeParams: typeof SupplyState.$numTypeParams = SupplyState.$numTypeParams
   static readonly $isPhantom: typeof SupplyState.$isPhantom = SupplyState.$isPhantom
   static readonly $variantName = 'BurnOnly' as const
@@ -2414,7 +2468,9 @@ export type SupplyStateUnknownJSON<T extends PhantomTypeArgument> = {
 export class SupplyStateUnknown<T extends PhantomTypeArgument> implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof SupplyState.$typeName = SupplyState.$typeName
+  static get $typeName(): typeof SupplyState.$typeName {
+    return SupplyState.$typeName
+  }
   static readonly $numTypeParams: typeof SupplyState.$numTypeParams = SupplyState.$numTypeParams
   static readonly $isPhantom: typeof SupplyState.$isPhantom = SupplyState.$isPhantom
   static readonly $variantName = 'Unknown' as const
@@ -2496,10 +2552,12 @@ export class RegulatedState {
   static reified(): RegulatedStateReified {
     const reifiedBcs = RegulatedState.bcs
     return {
-      typeName: RegulatedState.$typeName,
-      fullTypeName: composeSuiType(
-        RegulatedState.$typeName,
-      ) as `0x2::coin_registry::RegulatedState`,
+      get typeName() {
+        return RegulatedState.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(RegulatedState.$typeName) as `0x2::coin_registry::RegulatedState`
+      },
       typeArgs: [] as [],
       isPhantom: RegulatedState.$isPhantom,
       reifiedTypeArgs: [],
@@ -2670,7 +2728,9 @@ export type RegulatedStateRegulatedJSON = {
 export class RegulatedStateRegulated implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof RegulatedState.$typeName = RegulatedState.$typeName
+  static get $typeName(): typeof RegulatedState.$typeName {
+    return RegulatedState.$typeName
+  }
   static readonly $numTypeParams: typeof RegulatedState.$numTypeParams =
     RegulatedState.$numTypeParams
   static readonly $isPhantom: typeof RegulatedState.$isPhantom = RegulatedState.$isPhantom
@@ -2737,7 +2797,9 @@ export type RegulatedStateUnregulatedJSON = {
 export class RegulatedStateUnregulated implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof RegulatedState.$typeName = RegulatedState.$typeName
+  static get $typeName(): typeof RegulatedState.$typeName {
+    return RegulatedState.$typeName
+  }
   static readonly $numTypeParams: typeof RegulatedState.$numTypeParams =
     RegulatedState.$numTypeParams
   static readonly $isPhantom: typeof RegulatedState.$isPhantom = RegulatedState.$isPhantom
@@ -2792,7 +2854,9 @@ export type RegulatedStateUnknownJSON = {
 export class RegulatedStateUnknown implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof RegulatedState.$typeName = RegulatedState.$typeName
+  static get $typeName(): typeof RegulatedState.$typeName {
+    return RegulatedState.$typeName
+  }
   static readonly $numTypeParams: typeof RegulatedState.$numTypeParams =
     RegulatedState.$numTypeParams
   static readonly $isPhantom: typeof RegulatedState.$isPhantom = RegulatedState.$isPhantom
@@ -2873,10 +2937,12 @@ export class MetadataCapState {
   static reified(): MetadataCapStateReified {
     const reifiedBcs = MetadataCapState.bcs
     return {
-      typeName: MetadataCapState.$typeName,
-      fullTypeName: composeSuiType(
-        MetadataCapState.$typeName,
-      ) as `0x2::coin_registry::MetadataCapState`,
+      get typeName() {
+        return MetadataCapState.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(MetadataCapState.$typeName) as `0x2::coin_registry::MetadataCapState`
+      },
       typeArgs: [] as [],
       isPhantom: MetadataCapState.$isPhantom,
       reifiedTypeArgs: [],
@@ -3025,7 +3091,9 @@ export type MetadataCapStateClaimedJSON = {
 export class MetadataCapStateClaimed implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof MetadataCapState.$typeName = MetadataCapState.$typeName
+  static get $typeName(): typeof MetadataCapState.$typeName {
+    return MetadataCapState.$typeName
+  }
   static readonly $numTypeParams: typeof MetadataCapState.$numTypeParams =
     MetadataCapState.$numTypeParams
   static readonly $isPhantom: typeof MetadataCapState.$isPhantom = MetadataCapState.$isPhantom
@@ -3085,7 +3153,9 @@ export type MetadataCapStateUnclaimedJSON = {
 export class MetadataCapStateUnclaimed implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof MetadataCapState.$typeName = MetadataCapState.$typeName
+  static get $typeName(): typeof MetadataCapState.$typeName {
+    return MetadataCapState.$typeName
+  }
   static readonly $numTypeParams: typeof MetadataCapState.$numTypeParams =
     MetadataCapState.$numTypeParams
   static readonly $isPhantom: typeof MetadataCapState.$isPhantom = MetadataCapState.$isPhantom
@@ -3137,7 +3207,9 @@ export type MetadataCapStateDeletedJSON = {
 export class MetadataCapStateDeleted implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof MetadataCapState.$typeName = MetadataCapState.$typeName
+  static get $typeName(): typeof MetadataCapState.$typeName {
+    return MetadataCapState.$typeName
+  }
   static readonly $numTypeParams: typeof MetadataCapState.$numTypeParams =
     MetadataCapState.$numTypeParams
   static readonly $isPhantom: typeof MetadataCapState.$isPhantom = MetadataCapState.$isPhantom

--- a/ts/tests/gen/sui/coin/structs.ts
+++ b/ts/tests/gen/sui/coin/structs.ts
@@ -97,12 +97,18 @@ export class Coin<T extends PhantomTypeArgument> implements StructClass {
   ): CoinReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Coin.bcs
     return {
-      typeName: Coin.$typeName,
-      fullTypeName: composeSuiType(
-        Coin.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::Coin<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Coin.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Coin.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::Coin<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Coin.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Coin.fromFields(T, fields),
@@ -398,12 +404,18 @@ export class CoinMetadata<T extends PhantomTypeArgument> implements StructClass 
   ): CoinMetadataReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = CoinMetadata.bcs
     return {
-      typeName: CoinMetadata.$typeName,
-      fullTypeName: composeSuiType(
-        CoinMetadata.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::CoinMetadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return CoinMetadata.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CoinMetadata.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::CoinMetadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: CoinMetadata.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => CoinMetadata.fromFields(T, fields),
@@ -692,12 +704,18 @@ export class RegulatedCoinMetadata<T extends PhantomTypeArgument> implements Str
   ): RegulatedCoinMetadataReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = RegulatedCoinMetadata.bcs
     return {
-      typeName: RegulatedCoinMetadata.$typeName,
-      fullTypeName: composeSuiType(
-        RegulatedCoinMetadata.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::RegulatedCoinMetadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return RegulatedCoinMetadata.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RegulatedCoinMetadata.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::RegulatedCoinMetadata<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: RegulatedCoinMetadata.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => RegulatedCoinMetadata.fromFields(T, fields),
@@ -968,12 +986,18 @@ export class TreasuryCap<T extends PhantomTypeArgument> implements StructClass {
   ): TreasuryCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TreasuryCap.bcs
     return {
-      typeName: TreasuryCap.$typeName,
-      fullTypeName: composeSuiType(
-        TreasuryCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::TreasuryCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TreasuryCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TreasuryCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::TreasuryCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TreasuryCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TreasuryCap.fromFields(T, fields),
@@ -1236,12 +1260,18 @@ export class DenyCapV2<T extends PhantomTypeArgument> implements StructClass {
   ): DenyCapV2Reified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = DenyCapV2.bcs
     return {
-      typeName: DenyCapV2.$typeName,
-      fullTypeName: composeSuiType(
-        DenyCapV2.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::DenyCapV2<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return DenyCapV2.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DenyCapV2.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::DenyCapV2<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: DenyCapV2.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => DenyCapV2.fromFields(T, fields),
@@ -1493,12 +1523,18 @@ export class CurrencyCreated<T extends PhantomTypeArgument> implements StructCla
   ): CurrencyCreatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = CurrencyCreated.bcs
     return {
-      typeName: CurrencyCreated.$typeName,
-      fullTypeName: composeSuiType(
-        CurrencyCreated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::CurrencyCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return CurrencyCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          CurrencyCreated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::CurrencyCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: CurrencyCreated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => CurrencyCreated.fromFields(T, fields),
@@ -1746,12 +1782,18 @@ export class DenyCap<T extends PhantomTypeArgument> implements StructClass {
   ): DenyCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = DenyCap.bcs
     return {
-      typeName: DenyCap.$typeName,
-      fullTypeName: composeSuiType(
-        DenyCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::coin::DenyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return DenyCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DenyCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::coin::DenyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: DenyCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => DenyCap.fromFields(T, fields),

--- a/ts/tests/gen/sui/config/structs.ts
+++ b/ts/tests/gen/sui/config/structs.ts
@@ -88,12 +88,18 @@ export class Config<WriteCap extends PhantomTypeArgument> implements StructClass
   ): ConfigReified<ToPhantomTypeArgument<WriteCap>> {
     const reifiedBcs = Config.bcs
     return {
-      typeName: Config.$typeName,
-      fullTypeName: composeSuiType(
-        Config.$typeName,
-        ...[extractType(WriteCap)],
-      ) as `0x2::config::Config<${PhantomToTypeStr<ToPhantomTypeArgument<WriteCap>>}>`,
-      typeArgs: [extractType(WriteCap)] as [PhantomToTypeStr<ToPhantomTypeArgument<WriteCap>>],
+      get typeName() {
+        return Config.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Config.$typeName,
+          ...[extractType(WriteCap)],
+        ) as `0x2::config::Config<${PhantomToTypeStr<ToPhantomTypeArgument<WriteCap>>}>`
+      },
+      get typeArgs() {
+        return [extractType(WriteCap)] as [PhantomToTypeStr<ToPhantomTypeArgument<WriteCap>>]
+      },
       isPhantom: Config.$isPhantom,
       reifiedTypeArgs: [WriteCap],
       fromFields: (fields: Record<string, any>) => Config.fromFields(WriteCap, fields),
@@ -340,12 +346,18 @@ export class Setting<Value extends TypeArgument> implements StructClass {
   ): SettingReified<ToTypeArgument<Value>> {
     const reifiedBcs = Setting.bcs(toBcs(Value))
     return {
-      typeName: Setting.$typeName,
-      fullTypeName: composeSuiType(
-        Setting.$typeName,
-        ...[extractType(Value)],
-      ) as `0x2::config::Setting<${ToTypeStr<ToTypeArgument<Value>>}>`,
-      typeArgs: [extractType(Value)] as [ToTypeStr<ToTypeArgument<Value>>],
+      get typeName() {
+        return Setting.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Setting.$typeName,
+          ...[extractType(Value)],
+        ) as `0x2::config::Setting<${ToTypeStr<ToTypeArgument<Value>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Value)] as [ToTypeStr<ToTypeArgument<Value>>]
+      },
       isPhantom: Setting.$isPhantom,
       reifiedTypeArgs: [Value],
       fromFields: (fields: Record<string, any>) => Setting.fromFields(Value, fields),
@@ -608,12 +620,18 @@ export class SettingData<Value extends TypeArgument> implements StructClass {
   ): SettingDataReified<ToTypeArgument<Value>> {
     const reifiedBcs = SettingData.bcs(toBcs(Value))
     return {
-      typeName: SettingData.$typeName,
-      fullTypeName: composeSuiType(
-        SettingData.$typeName,
-        ...[extractType(Value)],
-      ) as `0x2::config::SettingData<${ToTypeStr<ToTypeArgument<Value>>}>`,
-      typeArgs: [extractType(Value)] as [ToTypeStr<ToTypeArgument<Value>>],
+      get typeName() {
+        return SettingData.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          SettingData.$typeName,
+          ...[extractType(Value)],
+        ) as `0x2::config::SettingData<${ToTypeStr<ToTypeArgument<Value>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Value)] as [ToTypeStr<ToTypeArgument<Value>>]
+      },
       isPhantom: SettingData.$isPhantom,
       reifiedTypeArgs: [Value],
       fromFields: (fields: Record<string, any>) => SettingData.fromFields(Value, fields),

--- a/ts/tests/gen/sui/deny-list/structs.ts
+++ b/ts/tests/gen/sui/deny-list/structs.ts
@@ -91,11 +91,15 @@ export class DenyList implements StructClass {
   static reified(): DenyListReified {
     const reifiedBcs = DenyList.bcs
     return {
-      typeName: DenyList.$typeName,
-      fullTypeName: composeSuiType(
-        DenyList.$typeName,
-        ...[],
-      ) as `0x2::deny_list::DenyList`,
+      get typeName() {
+        return DenyList.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DenyList.$typeName,
+          ...[],
+        ) as `0x2::deny_list::DenyList`
+      },
       typeArgs: [] as [],
       isPhantom: DenyList.$isPhantom,
       reifiedTypeArgs: [],
@@ -283,11 +287,15 @@ export class ConfigWriteCap implements StructClass {
   static reified(): ConfigWriteCapReified {
     const reifiedBcs = ConfigWriteCap.bcs
     return {
-      typeName: ConfigWriteCap.$typeName,
-      fullTypeName: composeSuiType(
-        ConfigWriteCap.$typeName,
-        ...[],
-      ) as `0x2::deny_list::ConfigWriteCap`,
+      get typeName() {
+        return ConfigWriteCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ConfigWriteCap.$typeName,
+          ...[],
+        ) as `0x2::deny_list::ConfigWriteCap`
+      },
       typeArgs: [] as [],
       isPhantom: ConfigWriteCap.$isPhantom,
       reifiedTypeArgs: [],
@@ -473,11 +481,15 @@ export class ConfigKey implements StructClass {
   static reified(): ConfigKeyReified {
     const reifiedBcs = ConfigKey.bcs
     return {
-      typeName: ConfigKey.$typeName,
-      fullTypeName: composeSuiType(
-        ConfigKey.$typeName,
-        ...[],
-      ) as `0x2::deny_list::ConfigKey`,
+      get typeName() {
+        return ConfigKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ConfigKey.$typeName,
+          ...[],
+        ) as `0x2::deny_list::ConfigKey`
+      },
       typeArgs: [] as [],
       isPhantom: ConfigKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -661,11 +673,15 @@ export class AddressKey implements StructClass {
   static reified(): AddressKeyReified {
     const reifiedBcs = AddressKey.bcs
     return {
-      typeName: AddressKey.$typeName,
-      fullTypeName: composeSuiType(
-        AddressKey.$typeName,
-        ...[],
-      ) as `0x2::deny_list::AddressKey`,
+      get typeName() {
+        return AddressKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          AddressKey.$typeName,
+          ...[],
+        ) as `0x2::deny_list::AddressKey`
+      },
       typeArgs: [] as [],
       isPhantom: AddressKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -848,11 +864,15 @@ export class GlobalPauseKey implements StructClass {
   static reified(): GlobalPauseKeyReified {
     const reifiedBcs = GlobalPauseKey.bcs
     return {
-      typeName: GlobalPauseKey.$typeName,
-      fullTypeName: composeSuiType(
-        GlobalPauseKey.$typeName,
-        ...[],
-      ) as `0x2::deny_list::GlobalPauseKey`,
+      get typeName() {
+        return GlobalPauseKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          GlobalPauseKey.$typeName,
+          ...[],
+        ) as `0x2::deny_list::GlobalPauseKey`
+      },
       typeArgs: [] as [],
       isPhantom: GlobalPauseKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -1039,11 +1059,15 @@ export class PerTypeConfigCreated implements StructClass {
   static reified(): PerTypeConfigCreatedReified {
     const reifiedBcs = PerTypeConfigCreated.bcs
     return {
-      typeName: PerTypeConfigCreated.$typeName,
-      fullTypeName: composeSuiType(
-        PerTypeConfigCreated.$typeName,
-        ...[],
-      ) as `0x2::deny_list::PerTypeConfigCreated`,
+      get typeName() {
+        return PerTypeConfigCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PerTypeConfigCreated.$typeName,
+          ...[],
+        ) as `0x2::deny_list::PerTypeConfigCreated`
+      },
       typeArgs: [] as [],
       isPhantom: PerTypeConfigCreated.$isPhantom,
       reifiedTypeArgs: [],
@@ -1259,11 +1283,15 @@ export class PerTypeList implements StructClass {
   static reified(): PerTypeListReified {
     const reifiedBcs = PerTypeList.bcs
     return {
-      typeName: PerTypeList.$typeName,
-      fullTypeName: composeSuiType(
-        PerTypeList.$typeName,
-        ...[],
-      ) as `0x2::deny_list::PerTypeList`,
+      get typeName() {
+        return PerTypeList.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PerTypeList.$typeName,
+          ...[],
+        ) as `0x2::deny_list::PerTypeList`
+      },
       typeArgs: [] as [],
       isPhantom: PerTypeList.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/derived-object/structs.ts
+++ b/ts/tests/gen/sui/derived-object/structs.ts
@@ -97,11 +97,15 @@ export class Claimed implements StructClass {
   static reified(): ClaimedReified {
     const reifiedBcs = Claimed.bcs
     return {
-      typeName: Claimed.$typeName,
-      fullTypeName: composeSuiType(
-        Claimed.$typeName,
-        ...[],
-      ) as `0x2::derived_object::Claimed`,
+      get typeName() {
+        return Claimed.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Claimed.$typeName,
+          ...[],
+        ) as `0x2::derived_object::Claimed`
+      },
       typeArgs: [] as [],
       isPhantom: Claimed.$isPhantom,
       reifiedTypeArgs: [],
@@ -286,12 +290,18 @@ export class DerivedObjectKey<K extends TypeArgument> implements StructClass {
   ): DerivedObjectKeyReified<ToTypeArgument<K>> {
     const reifiedBcs = DerivedObjectKey.bcs(toBcs(K))
     return {
-      typeName: DerivedObjectKey.$typeName,
-      fullTypeName: composeSuiType(
-        DerivedObjectKey.$typeName,
-        ...[extractType(K)],
-      ) as `0x2::derived_object::DerivedObjectKey<${ToTypeStr<ToTypeArgument<K>>}>`,
-      typeArgs: [extractType(K)] as [ToTypeStr<ToTypeArgument<K>>],
+      get typeName() {
+        return DerivedObjectKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DerivedObjectKey.$typeName,
+          ...[extractType(K)],
+        ) as `0x2::derived_object::DerivedObjectKey<${ToTypeStr<ToTypeArgument<K>>}>`
+      },
+      get typeArgs() {
+        return [extractType(K)] as [ToTypeStr<ToTypeArgument<K>>]
+      },
       isPhantom: DerivedObjectKey.$isPhantom,
       reifiedTypeArgs: [K],
       fromFields: (fields: Record<string, any>) => DerivedObjectKey.fromFields(K, fields),
@@ -525,8 +535,12 @@ export class ClaimedStatus {
   static reified(): ClaimedStatusReified {
     const reifiedBcs = ClaimedStatus.bcs
     return {
-      typeName: ClaimedStatus.$typeName,
-      fullTypeName: composeSuiType(ClaimedStatus.$typeName) as `0x2::derived_object::ClaimedStatus`,
+      get typeName() {
+        return ClaimedStatus.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(ClaimedStatus.$typeName) as `0x2::derived_object::ClaimedStatus`
+      },
       typeArgs: [] as [],
       isPhantom: ClaimedStatus.$isPhantom,
       reifiedTypeArgs: [],
@@ -647,7 +661,9 @@ export type ClaimedStatusReservedJSON = {
 export class ClaimedStatusReserved implements EnumVariantClass {
   __EnumVariantClass = true as const
 
-  static readonly $typeName: typeof ClaimedStatus.$typeName = ClaimedStatus.$typeName
+  static get $typeName(): typeof ClaimedStatus.$typeName {
+    return ClaimedStatus.$typeName
+  }
   static readonly $numTypeParams: typeof ClaimedStatus.$numTypeParams = ClaimedStatus.$numTypeParams
   static readonly $isPhantom: typeof ClaimedStatus.$isPhantom = ClaimedStatus.$isPhantom
   static readonly $variantName = 'Reserved' as const

--- a/ts/tests/gen/sui/display/structs.ts
+++ b/ts/tests/gen/sui/display/structs.ts
@@ -135,12 +135,18 @@ export class Display<T extends PhantomTypeArgument> implements StructClass {
   ): DisplayReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Display.bcs
     return {
-      typeName: Display.$typeName,
-      fullTypeName: composeSuiType(
-        Display.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::display::Display<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Display.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Display.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::display::Display<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Display.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Display.fromFields(T, fields),
@@ -409,12 +415,18 @@ export class DisplayCreated<T extends PhantomTypeArgument> implements StructClas
   ): DisplayCreatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = DisplayCreated.bcs
     return {
-      typeName: DisplayCreated.$typeName,
-      fullTypeName: composeSuiType(
-        DisplayCreated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::display::DisplayCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return DisplayCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          DisplayCreated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::display::DisplayCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: DisplayCreated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => DisplayCreated.fromFields(T, fields),
@@ -671,12 +683,18 @@ export class VersionUpdated<T extends PhantomTypeArgument> implements StructClas
   ): VersionUpdatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = VersionUpdated.bcs
     return {
-      typeName: VersionUpdated.$typeName,
-      fullTypeName: composeSuiType(
-        VersionUpdated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::display::VersionUpdated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return VersionUpdated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VersionUpdated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::display::VersionUpdated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: VersionUpdated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => VersionUpdated.fromFields(T, fields),

--- a/ts/tests/gen/sui/dynamic-field/structs.ts
+++ b/ts/tests/gen/sui/dynamic-field/structs.ts
@@ -118,17 +118,23 @@ export class Field<Name extends TypeArgument, Value extends TypeArgument> implem
   ): FieldReified<ToTypeArgument<Name>, ToTypeArgument<Value>> {
     const reifiedBcs = Field.bcs(toBcs(Name), toBcs(Value))
     return {
-      typeName: Field.$typeName,
-      fullTypeName: composeSuiType(
-        Field.$typeName,
-        ...[extractType(Name), extractType(Value)],
-      ) as `0x2::dynamic_field::Field<${ToTypeStr<ToTypeArgument<Name>>}, ${ToTypeStr<
-        ToTypeArgument<Value>
-      >}>`,
-      typeArgs: [extractType(Name), extractType(Value)] as [
-        ToTypeStr<ToTypeArgument<Name>>,
-        ToTypeStr<ToTypeArgument<Value>>,
-      ],
+      get typeName() {
+        return Field.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Field.$typeName,
+          ...[extractType(Name), extractType(Value)],
+        ) as `0x2::dynamic_field::Field<${ToTypeStr<ToTypeArgument<Name>>}, ${ToTypeStr<
+          ToTypeArgument<Value>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(Name), extractType(Value)] as [
+          ToTypeStr<ToTypeArgument<Name>>,
+          ToTypeStr<ToTypeArgument<Value>>,
+        ]
+      },
       isPhantom: Field.$isPhantom,
       reifiedTypeArgs: [Name, Value],
       fromFields: (fields: Record<string, any>) => Field.fromFields([Name, Value], fields),

--- a/ts/tests/gen/sui/dynamic-object-field/structs.ts
+++ b/ts/tests/gen/sui/dynamic-object-field/structs.ts
@@ -88,12 +88,18 @@ export class Wrapper<Name extends TypeArgument> implements StructClass {
   ): WrapperReified<ToTypeArgument<Name>> {
     const reifiedBcs = Wrapper.bcs(toBcs(Name))
     return {
-      typeName: Wrapper.$typeName,
-      fullTypeName: composeSuiType(
-        Wrapper.$typeName,
-        ...[extractType(Name)],
-      ) as `0x2::dynamic_object_field::Wrapper<${ToTypeStr<ToTypeArgument<Name>>}>`,
-      typeArgs: [extractType(Name)] as [ToTypeStr<ToTypeArgument<Name>>],
+      get typeName() {
+        return Wrapper.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Wrapper.$typeName,
+          ...[extractType(Name)],
+        ) as `0x2::dynamic_object_field::Wrapper<${ToTypeStr<ToTypeArgument<Name>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Name)] as [ToTypeStr<ToTypeArgument<Name>>]
+      },
       isPhantom: Wrapper.$isPhantom,
       reifiedTypeArgs: [Name],
       fromFields: (fields: Record<string, any>) => Wrapper.fromFields(Name, fields),

--- a/ts/tests/gen/sui/funds-accumulator/structs.ts
+++ b/ts/tests/gen/sui/funds-accumulator/structs.ts
@@ -104,12 +104,18 @@ export class Withdrawal<T extends PhantomTypeArgument> implements StructClass {
   ): WithdrawalReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Withdrawal.bcs
     return {
-      typeName: Withdrawal.$typeName,
-      fullTypeName: composeSuiType(
-        Withdrawal.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::funds_accumulator::Withdrawal<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Withdrawal.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Withdrawal.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::funds_accumulator::Withdrawal<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Withdrawal.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Withdrawal.fromFields(T, fields),

--- a/ts/tests/gen/sui/groth16/structs.ts
+++ b/ts/tests/gen/sui/groth16/structs.ts
@@ -77,11 +77,15 @@ export class Curve implements StructClass {
   static reified(): CurveReified {
     const reifiedBcs = Curve.bcs
     return {
-      typeName: Curve.$typeName,
-      fullTypeName: composeSuiType(
-        Curve.$typeName,
-        ...[],
-      ) as `0x2::groth16::Curve`,
+      get typeName() {
+        return Curve.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Curve.$typeName,
+          ...[],
+        ) as `0x2::groth16::Curve`
+      },
       typeArgs: [] as [],
       isPhantom: Curve.$isPhantom,
       reifiedTypeArgs: [],
@@ -273,11 +277,15 @@ export class PreparedVerifyingKey implements StructClass {
   static reified(): PreparedVerifyingKeyReified {
     const reifiedBcs = PreparedVerifyingKey.bcs
     return {
-      typeName: PreparedVerifyingKey.$typeName,
-      fullTypeName: composeSuiType(
-        PreparedVerifyingKey.$typeName,
-        ...[],
-      ) as `0x2::groth16::PreparedVerifyingKey`,
+      get typeName() {
+        return PreparedVerifyingKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PreparedVerifyingKey.$typeName,
+          ...[],
+        ) as `0x2::groth16::PreparedVerifyingKey`
+      },
       typeArgs: [] as [],
       isPhantom: PreparedVerifyingKey.$isPhantom,
       reifiedTypeArgs: [],
@@ -481,11 +489,15 @@ export class PublicProofInputs implements StructClass {
   static reified(): PublicProofInputsReified {
     const reifiedBcs = PublicProofInputs.bcs
     return {
-      typeName: PublicProofInputs.$typeName,
-      fullTypeName: composeSuiType(
-        PublicProofInputs.$typeName,
-        ...[],
-      ) as `0x2::groth16::PublicProofInputs`,
+      get typeName() {
+        return PublicProofInputs.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PublicProofInputs.$typeName,
+          ...[],
+        ) as `0x2::groth16::PublicProofInputs`
+      },
       typeArgs: [] as [],
       isPhantom: PublicProofInputs.$isPhantom,
       reifiedTypeArgs: [],
@@ -664,11 +676,15 @@ export class ProofPoints implements StructClass {
   static reified(): ProofPointsReified {
     const reifiedBcs = ProofPoints.bcs
     return {
-      typeName: ProofPoints.$typeName,
-      fullTypeName: composeSuiType(
-        ProofPoints.$typeName,
-        ...[],
-      ) as `0x2::groth16::ProofPoints`,
+      get typeName() {
+        return ProofPoints.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ProofPoints.$typeName,
+          ...[],
+        ) as `0x2::groth16::ProofPoints`
+      },
       typeArgs: [] as [],
       isPhantom: ProofPoints.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/group-ops/structs.ts
+++ b/ts/tests/gen/sui/group-ops/structs.ts
@@ -84,12 +84,18 @@ export class Element<T extends PhantomTypeArgument> implements StructClass {
   ): ElementReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Element.bcs
     return {
-      typeName: Element.$typeName,
-      fullTypeName: composeSuiType(
-        Element.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::group_ops::Element<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Element.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Element.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::group_ops::Element<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Element.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Element.fromFields(T, fields),

--- a/ts/tests/gen/sui/kiosk-extension/structs.ts
+++ b/ts/tests/gen/sui/kiosk-extension/structs.ts
@@ -186,11 +186,15 @@ export class Extension implements StructClass {
   static reified(): ExtensionReified {
     const reifiedBcs = Extension.bcs
     return {
-      typeName: Extension.$typeName,
-      fullTypeName: composeSuiType(
-        Extension.$typeName,
-        ...[],
-      ) as `0x2::kiosk_extension::Extension`,
+      get typeName() {
+        return Extension.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Extension.$typeName,
+          ...[],
+        ) as `0x2::kiosk_extension::Extension`
+      },
       typeArgs: [] as [],
       isPhantom: Extension.$isPhantom,
       reifiedTypeArgs: [],
@@ -389,12 +393,18 @@ export class ExtensionKey<Ext extends PhantomTypeArgument> implements StructClas
   ): ExtensionKeyReified<ToPhantomTypeArgument<Ext>> {
     const reifiedBcs = ExtensionKey.bcs
     return {
-      typeName: ExtensionKey.$typeName,
-      fullTypeName: composeSuiType(
-        ExtensionKey.$typeName,
-        ...[extractType(Ext)],
-      ) as `0x2::kiosk_extension::ExtensionKey<${PhantomToTypeStr<ToPhantomTypeArgument<Ext>>}>`,
-      typeArgs: [extractType(Ext)] as [PhantomToTypeStr<ToPhantomTypeArgument<Ext>>],
+      get typeName() {
+        return ExtensionKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ExtensionKey.$typeName,
+          ...[extractType(Ext)],
+        ) as `0x2::kiosk_extension::ExtensionKey<${PhantomToTypeStr<ToPhantomTypeArgument<Ext>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Ext)] as [PhantomToTypeStr<ToPhantomTypeArgument<Ext>>]
+      },
       isPhantom: ExtensionKey.$isPhantom,
       reifiedTypeArgs: [Ext],
       fromFields: (fields: Record<string, any>) => ExtensionKey.fromFields(Ext, fields),

--- a/ts/tests/gen/sui/kiosk/structs.ts
+++ b/ts/tests/gen/sui/kiosk/structs.ts
@@ -217,11 +217,15 @@ export class Kiosk implements StructClass {
   static reified(): KioskReified {
     const reifiedBcs = Kiosk.bcs
     return {
-      typeName: Kiosk.$typeName,
-      fullTypeName: composeSuiType(
-        Kiosk.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Kiosk`,
+      get typeName() {
+        return Kiosk.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Kiosk.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Kiosk`
+      },
       typeArgs: [] as [],
       isPhantom: Kiosk.$isPhantom,
       reifiedTypeArgs: [],
@@ -433,11 +437,15 @@ export class KioskOwnerCap implements StructClass {
   static reified(): KioskOwnerCapReified {
     const reifiedBcs = KioskOwnerCap.bcs
     return {
-      typeName: KioskOwnerCap.$typeName,
-      fullTypeName: composeSuiType(
-        KioskOwnerCap.$typeName,
-        ...[],
-      ) as `0x2::kiosk::KioskOwnerCap`,
+      get typeName() {
+        return KioskOwnerCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          KioskOwnerCap.$typeName,
+          ...[],
+        ) as `0x2::kiosk::KioskOwnerCap`
+      },
       typeArgs: [] as [],
       isPhantom: KioskOwnerCap.$isPhantom,
       reifiedTypeArgs: [],
@@ -654,12 +662,18 @@ export class PurchaseCap<T extends PhantomTypeArgument> implements StructClass {
   ): PurchaseCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = PurchaseCap.bcs
     return {
-      typeName: PurchaseCap.$typeName,
-      fullTypeName: composeSuiType(
-        PurchaseCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::kiosk::PurchaseCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return PurchaseCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PurchaseCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::kiosk::PurchaseCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: PurchaseCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => PurchaseCap.fromFields(T, fields),
@@ -924,11 +938,15 @@ export class Borrow implements StructClass {
   static reified(): BorrowReified {
     const reifiedBcs = Borrow.bcs
     return {
-      typeName: Borrow.$typeName,
-      fullTypeName: composeSuiType(
-        Borrow.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Borrow`,
+      get typeName() {
+        return Borrow.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Borrow.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Borrow`
+      },
       typeArgs: [] as [],
       isPhantom: Borrow.$isPhantom,
       reifiedTypeArgs: [],
@@ -1112,11 +1130,15 @@ export class Item implements StructClass {
   static reified(): ItemReified {
     const reifiedBcs = Item.bcs
     return {
-      typeName: Item.$typeName,
-      fullTypeName: composeSuiType(
-        Item.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Item`,
+      get typeName() {
+        return Item.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Item.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Item`
+      },
       typeArgs: [] as [],
       isPhantom: Item.$isPhantom,
       reifiedTypeArgs: [],
@@ -1302,11 +1324,15 @@ export class Listing implements StructClass {
   static reified(): ListingReified {
     const reifiedBcs = Listing.bcs
     return {
-      typeName: Listing.$typeName,
-      fullTypeName: composeSuiType(
-        Listing.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Listing`,
+      get typeName() {
+        return Listing.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Listing.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Listing`
+      },
       typeArgs: [] as [],
       isPhantom: Listing.$isPhantom,
       reifiedTypeArgs: [],
@@ -1494,11 +1520,15 @@ export class Lock implements StructClass {
   static reified(): LockReified {
     const reifiedBcs = Lock.bcs
     return {
-      typeName: Lock.$typeName,
-      fullTypeName: composeSuiType(
-        Lock.$typeName,
-        ...[],
-      ) as `0x2::kiosk::Lock`,
+      get typeName() {
+        return Lock.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Lock.$typeName,
+          ...[],
+        ) as `0x2::kiosk::Lock`
+      },
       typeArgs: [] as [],
       isPhantom: Lock.$isPhantom,
       reifiedTypeArgs: [],
@@ -1694,12 +1724,18 @@ export class ItemListed<T extends PhantomTypeArgument> implements StructClass {
   ): ItemListedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = ItemListed.bcs
     return {
-      typeName: ItemListed.$typeName,
-      fullTypeName: composeSuiType(
-        ItemListed.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::kiosk::ItemListed<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return ItemListed.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ItemListed.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::kiosk::ItemListed<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: ItemListed.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => ItemListed.fromFields(T, fields),
@@ -1975,12 +2011,18 @@ export class ItemPurchased<T extends PhantomTypeArgument> implements StructClass
   ): ItemPurchasedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = ItemPurchased.bcs
     return {
-      typeName: ItemPurchased.$typeName,
-      fullTypeName: composeSuiType(
-        ItemPurchased.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::kiosk::ItemPurchased<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return ItemPurchased.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ItemPurchased.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::kiosk::ItemPurchased<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: ItemPurchased.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => ItemPurchased.fromFields(T, fields),
@@ -2245,12 +2287,18 @@ export class ItemDelisted<T extends PhantomTypeArgument> implements StructClass 
   ): ItemDelistedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = ItemDelisted.bcs
     return {
-      typeName: ItemDelisted.$typeName,
-      fullTypeName: composeSuiType(
-        ItemDelisted.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::kiosk::ItemDelisted<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return ItemDelisted.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ItemDelisted.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::kiosk::ItemDelisted<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: ItemDelisted.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => ItemDelisted.fromFields(T, fields),

--- a/ts/tests/gen/sui/linked-table/structs.ts
+++ b/ts/tests/gen/sui/linked-table/structs.ts
@@ -123,17 +123,23 @@ export class LinkedTable<K extends TypeArgument, V extends PhantomTypeArgument>
   ): LinkedTableReified<ToTypeArgument<K>, ToPhantomTypeArgument<V>> {
     const reifiedBcs = LinkedTable.bcs(toBcs(K))
     return {
-      typeName: LinkedTable.$typeName,
-      fullTypeName: composeSuiType(
-        LinkedTable.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::linked_table::LinkedTable<${ToTypeStr<ToTypeArgument<K>>}, ${PhantomToTypeStr<
-        ToPhantomTypeArgument<V>
-      >}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<K>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<V>>,
-      ],
+      get typeName() {
+        return LinkedTable.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          LinkedTable.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::linked_table::LinkedTable<${ToTypeStr<ToTypeArgument<K>>}, ${PhantomToTypeStr<
+          ToPhantomTypeArgument<V>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<K>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<V>>,
+        ]
+      },
       isPhantom: LinkedTable.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => LinkedTable.fromFields([K, V], fields),
@@ -440,17 +446,23 @@ export class Node<K extends TypeArgument, V extends TypeArgument> implements Str
   ): NodeReified<ToTypeArgument<K>, ToTypeArgument<V>> {
     const reifiedBcs = Node.bcs(toBcs(K), toBcs(V))
     return {
-      typeName: Node.$typeName,
-      fullTypeName: composeSuiType(
-        Node.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::linked_table::Node<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<
-        ToTypeArgument<V>
-      >}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<K>>,
-        ToTypeStr<ToTypeArgument<V>>,
-      ],
+      get typeName() {
+        return Node.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Node.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::linked_table::Node<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<
+          ToTypeArgument<V>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<K>>,
+          ToTypeStr<ToTypeArgument<V>>,
+        ]
+      },
       isPhantom: Node.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => Node.fromFields([K, V], fields),

--- a/ts/tests/gen/sui/nitro-attestation/structs.ts
+++ b/ts/tests/gen/sui/nitro-attestation/structs.ts
@@ -80,11 +80,15 @@ export class PCREntry implements StructClass {
   static reified(): PCREntryReified {
     const reifiedBcs = PCREntry.bcs
     return {
-      typeName: PCREntry.$typeName,
-      fullTypeName: composeSuiType(
-        PCREntry.$typeName,
-        ...[],
-      ) as `0x2::nitro_attestation::PCREntry`,
+      get typeName() {
+        return PCREntry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PCREntry.$typeName,
+          ...[],
+        ) as `0x2::nitro_attestation::PCREntry`
+      },
       typeArgs: [] as [],
       isPhantom: PCREntry.$isPhantom,
       reifiedTypeArgs: [],
@@ -323,11 +327,15 @@ export class NitroAttestationDocument implements StructClass {
   static reified(): NitroAttestationDocumentReified {
     const reifiedBcs = NitroAttestationDocument.bcs
     return {
-      typeName: NitroAttestationDocument.$typeName,
-      fullTypeName: composeSuiType(
-        NitroAttestationDocument.$typeName,
-        ...[],
-      ) as `0x2::nitro_attestation::NitroAttestationDocument`,
+      get typeName() {
+        return NitroAttestationDocument.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          NitroAttestationDocument.$typeName,
+          ...[],
+        ) as `0x2::nitro_attestation::NitroAttestationDocument`
+      },
       typeArgs: [] as [],
       isPhantom: NitroAttestationDocument.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/object-bag/structs.ts
+++ b/ts/tests/gen/sui/object-bag/structs.ts
@@ -86,11 +86,15 @@ export class ObjectBag implements StructClass {
   static reified(): ObjectBagReified {
     const reifiedBcs = ObjectBag.bcs
     return {
-      typeName: ObjectBag.$typeName,
-      fullTypeName: composeSuiType(
-        ObjectBag.$typeName,
-        ...[],
-      ) as `0x2::object_bag::ObjectBag`,
+      get typeName() {
+        return ObjectBag.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ObjectBag.$typeName,
+          ...[],
+        ) as `0x2::object_bag::ObjectBag`
+      },
       typeArgs: [] as [],
       isPhantom: ObjectBag.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/object-table/structs.ts
+++ b/ts/tests/gen/sui/object-table/structs.ts
@@ -108,17 +108,23 @@ export class ObjectTable<K extends PhantomTypeArgument, V extends PhantomTypeArg
   ): ObjectTableReified<ToPhantomTypeArgument<K>, ToPhantomTypeArgument<V>> {
     const reifiedBcs = ObjectTable.bcs
     return {
-      typeName: ObjectTable.$typeName,
-      fullTypeName: composeSuiType(
-        ObjectTable.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::object_table::ObjectTable<${PhantomToTypeStr<
-        ToPhantomTypeArgument<K>
-      >}, ${PhantomToTypeStr<ToPhantomTypeArgument<V>>}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        PhantomToTypeStr<ToPhantomTypeArgument<K>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<V>>,
-      ],
+      get typeName() {
+        return ObjectTable.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ObjectTable.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::object_table::ObjectTable<${PhantomToTypeStr<
+          ToPhantomTypeArgument<K>
+        >}, ${PhantomToTypeStr<ToPhantomTypeArgument<V>>}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          PhantomToTypeStr<ToPhantomTypeArgument<K>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<V>>,
+        ]
+      },
       isPhantom: ObjectTable.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => ObjectTable.fromFields([K, V], fields),

--- a/ts/tests/gen/sui/object/structs.ts
+++ b/ts/tests/gen/sui/object/structs.ts
@@ -80,11 +80,15 @@ export class ID implements StructClass {
   static reified(): IDReified {
     const reifiedBcs = ID.bcs
     return {
-      typeName: ID.$typeName,
-      fullTypeName: composeSuiType(
-        ID.$typeName,
-        ...[],
-      ) as `0x2::object::ID`,
+      get typeName() {
+        return ID.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ID.$typeName,
+          ...[],
+        ) as `0x2::object::ID`
+      },
       typeArgs: [] as [],
       isPhantom: ID.$isPhantom,
       reifiedTypeArgs: [],
@@ -273,11 +277,15 @@ export class UID implements StructClass {
   static reified(): UIDReified {
     const reifiedBcs = UID.bcs
     return {
-      typeName: UID.$typeName,
-      fullTypeName: composeSuiType(
-        UID.$typeName,
-        ...[],
-      ) as `0x2::object::UID`,
+      get typeName() {
+        return UID.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UID.$typeName,
+          ...[],
+        ) as `0x2::object::UID`
+      },
       typeArgs: [] as [],
       isPhantom: UID.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/package/structs.ts
+++ b/ts/tests/gen/sui/package/structs.ts
@@ -95,11 +95,15 @@ export class Publisher implements StructClass {
   static reified(): PublisherReified {
     const reifiedBcs = Publisher.bcs
     return {
-      typeName: Publisher.$typeName,
-      fullTypeName: composeSuiType(
-        Publisher.$typeName,
-        ...[],
-      ) as `0x2::package::Publisher`,
+      get typeName() {
+        return Publisher.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Publisher.$typeName,
+          ...[],
+        ) as `0x2::package::Publisher`
+      },
       typeArgs: [] as [],
       isPhantom: Publisher.$isPhantom,
       reifiedTypeArgs: [],
@@ -312,11 +316,15 @@ export class UpgradeCap implements StructClass {
   static reified(): UpgradeCapReified {
     const reifiedBcs = UpgradeCap.bcs
     return {
-      typeName: UpgradeCap.$typeName,
-      fullTypeName: composeSuiType(
-        UpgradeCap.$typeName,
-        ...[],
-      ) as `0x2::package::UpgradeCap`,
+      get typeName() {
+        return UpgradeCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UpgradeCap.$typeName,
+          ...[],
+        ) as `0x2::package::UpgradeCap`
+      },
       typeArgs: [] as [],
       isPhantom: UpgradeCap.$isPhantom,
       reifiedTypeArgs: [],
@@ -551,11 +559,15 @@ export class UpgradeTicket implements StructClass {
   static reified(): UpgradeTicketReified {
     const reifiedBcs = UpgradeTicket.bcs
     return {
-      typeName: UpgradeTicket.$typeName,
-      fullTypeName: composeSuiType(
-        UpgradeTicket.$typeName,
-        ...[],
-      ) as `0x2::package::UpgradeTicket`,
+      get typeName() {
+        return UpgradeTicket.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UpgradeTicket.$typeName,
+          ...[],
+        ) as `0x2::package::UpgradeTicket`
+      },
       typeArgs: [] as [],
       isPhantom: UpgradeTicket.$isPhantom,
       reifiedTypeArgs: [],
@@ -763,11 +775,15 @@ export class UpgradeReceipt implements StructClass {
   static reified(): UpgradeReceiptReified {
     const reifiedBcs = UpgradeReceipt.bcs
     return {
-      typeName: UpgradeReceipt.$typeName,
-      fullTypeName: composeSuiType(
-        UpgradeReceipt.$typeName,
-        ...[],
-      ) as `0x2::package::UpgradeReceipt`,
+      get typeName() {
+        return UpgradeReceipt.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          UpgradeReceipt.$typeName,
+          ...[],
+        ) as `0x2::package::UpgradeReceipt`
+      },
       typeArgs: [] as [],
       isPhantom: UpgradeReceipt.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/party/structs.ts
+++ b/ts/tests/gen/sui/party/structs.ts
@@ -88,11 +88,15 @@ export class Party implements StructClass {
   static reified(): PartyReified {
     const reifiedBcs = Party.bcs
     return {
-      typeName: Party.$typeName,
-      fullTypeName: composeSuiType(
-        Party.$typeName,
-        ...[],
-      ) as `0x2::party::Party`,
+      get typeName() {
+        return Party.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Party.$typeName,
+          ...[],
+        ) as `0x2::party::Party`
+      },
       typeArgs: [] as [],
       isPhantom: Party.$isPhantom,
       reifiedTypeArgs: [],
@@ -288,11 +292,15 @@ export class Permissions implements StructClass {
   static reified(): PermissionsReified {
     const reifiedBcs = Permissions.bcs
     return {
-      typeName: Permissions.$typeName,
-      fullTypeName: composeSuiType(
-        Permissions.$typeName,
-        ...[],
-      ) as `0x2::party::Permissions`,
+      get typeName() {
+        return Permissions.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Permissions.$typeName,
+          ...[],
+        ) as `0x2::party::Permissions`
+      },
       typeArgs: [] as [],
       isPhantom: Permissions.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/priority-queue/structs.ts
+++ b/ts/tests/gen/sui/priority-queue/structs.ts
@@ -95,12 +95,18 @@ export class PriorityQueue<T extends TypeArgument> implements StructClass {
   ): PriorityQueueReified<ToTypeArgument<T>> {
     const reifiedBcs = PriorityQueue.bcs(toBcs(T))
     return {
-      typeName: PriorityQueue.$typeName,
-      fullTypeName: composeSuiType(
-        PriorityQueue.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::priority_queue::PriorityQueue<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return PriorityQueue.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          PriorityQueue.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::priority_queue::PriorityQueue<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: PriorityQueue.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => PriorityQueue.fromFields(T, fields),
@@ -353,12 +359,18 @@ export class Entry<T extends TypeArgument> implements StructClass {
   ): EntryReified<ToTypeArgument<T>> {
     const reifiedBcs = Entry.bcs(toBcs(T))
     return {
-      typeName: Entry.$typeName,
-      fullTypeName: composeSuiType(
-        Entry.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::priority_queue::Entry<${ToTypeStr<ToTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>],
+      get typeName() {
+        return Entry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Entry.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::priority_queue::Entry<${ToTypeStr<ToTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [ToTypeStr<ToTypeArgument<T>>]
+      },
       isPhantom: Entry.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Entry.fromFields(T, fields),

--- a/ts/tests/gen/sui/random/structs.ts
+++ b/ts/tests/gen/sui/random/structs.ts
@@ -85,11 +85,15 @@ export class Random implements StructClass {
   static reified(): RandomReified {
     const reifiedBcs = Random.bcs
     return {
-      typeName: Random.$typeName,
-      fullTypeName: composeSuiType(
-        Random.$typeName,
-        ...[],
-      ) as `0x2::random::Random`,
+      get typeName() {
+        return Random.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Random.$typeName,
+          ...[],
+        ) as `0x2::random::Random`
+      },
       typeArgs: [] as [],
       isPhantom: Random.$isPhantom,
       reifiedTypeArgs: [],
@@ -284,11 +288,15 @@ export class RandomInner implements StructClass {
   static reified(): RandomInnerReified {
     const reifiedBcs = RandomInner.bcs
     return {
-      typeName: RandomInner.$typeName,
-      fullTypeName: composeSuiType(
-        RandomInner.$typeName,
-        ...[],
-      ) as `0x2::random::RandomInner`,
+      get typeName() {
+        return RandomInner.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RandomInner.$typeName,
+          ...[],
+        ) as `0x2::random::RandomInner`
+      },
       typeArgs: [] as [],
       isPhantom: RandomInner.$isPhantom,
       reifiedTypeArgs: [],
@@ -491,11 +499,15 @@ export class RandomGenerator implements StructClass {
   static reified(): RandomGeneratorReified {
     const reifiedBcs = RandomGenerator.bcs
     return {
-      typeName: RandomGenerator.$typeName,
-      fullTypeName: composeSuiType(
-        RandomGenerator.$typeName,
-        ...[],
-      ) as `0x2::random::RandomGenerator`,
+      get typeName() {
+        return RandomGenerator.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RandomGenerator.$typeName,
+          ...[],
+        ) as `0x2::random::RandomGenerator`
+      },
       typeArgs: [] as [],
       isPhantom: RandomGenerator.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/sui/structs.ts
+++ b/ts/tests/gen/sui/sui/structs.ts
@@ -76,11 +76,15 @@ export class SUI implements StructClass {
   static reified(): SUIReified {
     const reifiedBcs = SUI.bcs
     return {
-      typeName: SUI.$typeName,
-      fullTypeName: composeSuiType(
-        SUI.$typeName,
-        ...[],
-      ) as `0x2::sui::SUI`,
+      get typeName() {
+        return SUI.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          SUI.$typeName,
+          ...[],
+        ) as `0x2::sui::SUI`
+      },
       typeArgs: [] as [],
       isPhantom: SUI.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/table-vec/structs.ts
+++ b/ts/tests/gen/sui/table-vec/structs.ts
@@ -87,12 +87,18 @@ export class TableVec<Element extends PhantomTypeArgument> implements StructClas
   ): TableVecReified<ToPhantomTypeArgument<Element>> {
     const reifiedBcs = TableVec.bcs
     return {
-      typeName: TableVec.$typeName,
-      fullTypeName: composeSuiType(
-        TableVec.$typeName,
-        ...[extractType(Element)],
-      ) as `0x2::table_vec::TableVec<${PhantomToTypeStr<ToPhantomTypeArgument<Element>>}>`,
-      typeArgs: [extractType(Element)] as [PhantomToTypeStr<ToPhantomTypeArgument<Element>>],
+      get typeName() {
+        return TableVec.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TableVec.$typeName,
+          ...[extractType(Element)],
+        ) as `0x2::table_vec::TableVec<${PhantomToTypeStr<ToPhantomTypeArgument<Element>>}>`
+      },
+      get typeArgs() {
+        return [extractType(Element)] as [PhantomToTypeStr<ToPhantomTypeArgument<Element>>]
+      },
       isPhantom: TableVec.$isPhantom,
       reifiedTypeArgs: [Element],
       fromFields: (fields: Record<string, any>) => TableVec.fromFields(Element, fields),

--- a/ts/tests/gen/sui/table/structs.ts
+++ b/ts/tests/gen/sui/table/structs.ts
@@ -118,17 +118,23 @@ export class Table<K extends PhantomTypeArgument, V extends PhantomTypeArgument>
   ): TableReified<ToPhantomTypeArgument<K>, ToPhantomTypeArgument<V>> {
     const reifiedBcs = Table.bcs
     return {
-      typeName: Table.$typeName,
-      fullTypeName: composeSuiType(
-        Table.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::table::Table<${PhantomToTypeStr<ToPhantomTypeArgument<K>>}, ${PhantomToTypeStr<
-        ToPhantomTypeArgument<V>
-      >}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        PhantomToTypeStr<ToPhantomTypeArgument<K>>,
-        PhantomToTypeStr<ToPhantomTypeArgument<V>>,
-      ],
+      get typeName() {
+        return Table.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Table.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::table::Table<${PhantomToTypeStr<ToPhantomTypeArgument<K>>}, ${PhantomToTypeStr<
+          ToPhantomTypeArgument<V>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          PhantomToTypeStr<ToPhantomTypeArgument<K>>,
+          PhantomToTypeStr<ToPhantomTypeArgument<V>>,
+        ]
+      },
       isPhantom: Table.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => Table.fromFields([K, V], fields),

--- a/ts/tests/gen/sui/token/structs.ts
+++ b/ts/tests/gen/sui/token/structs.ts
@@ -118,12 +118,18 @@ export class Token<T extends PhantomTypeArgument> implements StructClass {
   ): TokenReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Token.bcs
     return {
-      typeName: Token.$typeName,
-      fullTypeName: composeSuiType(
-        Token.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::Token<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Token.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Token.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::Token<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Token.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Token.fromFields(T, fields),
@@ -383,12 +389,18 @@ export class TokenPolicyCap<T extends PhantomTypeArgument> implements StructClas
   ): TokenPolicyCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TokenPolicyCap.bcs
     return {
-      typeName: TokenPolicyCap.$typeName,
-      fullTypeName: composeSuiType(
-        TokenPolicyCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::TokenPolicyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TokenPolicyCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TokenPolicyCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::TokenPolicyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TokenPolicyCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TokenPolicyCap.fromFields(T, fields),
@@ -685,12 +697,18 @@ export class TokenPolicy<T extends PhantomTypeArgument> implements StructClass {
   ): TokenPolicyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TokenPolicy.bcs
     return {
-      typeName: TokenPolicy.$typeName,
-      fullTypeName: composeSuiType(
-        TokenPolicy.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::TokenPolicy<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TokenPolicy.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TokenPolicy.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::TokenPolicy<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TokenPolicy.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TokenPolicy.fromFields(T, fields),
@@ -1015,12 +1033,18 @@ export class ActionRequest<T extends PhantomTypeArgument> implements StructClass
   ): ActionRequestReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = ActionRequest.bcs
     return {
-      typeName: ActionRequest.$typeName,
-      fullTypeName: composeSuiType(
-        ActionRequest.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::ActionRequest<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return ActionRequest.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          ActionRequest.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::ActionRequest<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: ActionRequest.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => ActionRequest.fromFields(T, fields),
@@ -1317,12 +1341,18 @@ export class RuleKey<T extends PhantomTypeArgument> implements StructClass {
   ): RuleKeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = RuleKey.bcs
     return {
-      typeName: RuleKey.$typeName,
-      fullTypeName: composeSuiType(
-        RuleKey.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::RuleKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return RuleKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RuleKey.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::RuleKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: RuleKey.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => RuleKey.fromFields(T, fields),
@@ -1589,12 +1619,18 @@ export class TokenPolicyCreated<T extends PhantomTypeArgument> implements Struct
   ): TokenPolicyCreatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TokenPolicyCreated.bcs
     return {
-      typeName: TokenPolicyCreated.$typeName,
-      fullTypeName: composeSuiType(
-        TokenPolicyCreated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::token::TokenPolicyCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TokenPolicyCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TokenPolicyCreated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::token::TokenPolicyCreated<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TokenPolicyCreated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TokenPolicyCreated.fromFields(T, fields),

--- a/ts/tests/gen/sui/transfer-policy/structs.ts
+++ b/ts/tests/gen/sui/transfer-policy/structs.ts
@@ -162,12 +162,18 @@ export class TransferRequest<T extends PhantomTypeArgument> implements StructCla
   ): TransferRequestReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferRequest.bcs
     return {
-      typeName: TransferRequest.$typeName,
-      fullTypeName: composeSuiType(
-        TransferRequest.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferRequest<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferRequest.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferRequest.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferRequest<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferRequest.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferRequest.fromFields(T, fields),
@@ -469,12 +475,18 @@ export class TransferPolicy<T extends PhantomTypeArgument> implements StructClas
   ): TransferPolicyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferPolicy.bcs
     return {
-      typeName: TransferPolicy.$typeName,
-      fullTypeName: composeSuiType(
-        TransferPolicy.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferPolicy<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferPolicy.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferPolicy.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferPolicy<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferPolicy.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferPolicy.fromFields(T, fields),
@@ -743,12 +755,20 @@ export class TransferPolicyCap<T extends PhantomTypeArgument> implements StructC
   ): TransferPolicyCapReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferPolicyCap.bcs
     return {
-      typeName: TransferPolicyCap.$typeName,
-      fullTypeName: composeSuiType(
-        TransferPolicyCap.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferPolicyCap<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferPolicyCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferPolicyCap.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferPolicyCap<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferPolicyCap.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferPolicyCap.fromFields(T, fields),
@@ -1009,14 +1029,20 @@ export class TransferPolicyCreated<T extends PhantomTypeArgument> implements Str
   ): TransferPolicyCreatedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferPolicyCreated.bcs
     return {
-      typeName: TransferPolicyCreated.$typeName,
-      fullTypeName: composeSuiType(
-        TransferPolicyCreated.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferPolicyCreated<${PhantomToTypeStr<
-        ToPhantomTypeArgument<T>
-      >}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferPolicyCreated.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferPolicyCreated.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferPolicyCreated<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferPolicyCreated.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferPolicyCreated.fromFields(T, fields),
@@ -1275,14 +1301,20 @@ export class TransferPolicyDestroyed<T extends PhantomTypeArgument> implements S
   ): TransferPolicyDestroyedReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = TransferPolicyDestroyed.bcs
     return {
-      typeName: TransferPolicyDestroyed.$typeName,
-      fullTypeName: composeSuiType(
-        TransferPolicyDestroyed.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::TransferPolicyDestroyed<${PhantomToTypeStr<
-        ToPhantomTypeArgument<T>
-      >}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return TransferPolicyDestroyed.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TransferPolicyDestroyed.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::TransferPolicyDestroyed<${PhantomToTypeStr<
+          ToPhantomTypeArgument<T>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: TransferPolicyDestroyed.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => TransferPolicyDestroyed.fromFields(T, fields),
@@ -1534,12 +1566,18 @@ export class RuleKey<T extends PhantomTypeArgument> implements StructClass {
   ): RuleKeyReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = RuleKey.bcs
     return {
-      typeName: RuleKey.$typeName,
-      fullTypeName: composeSuiType(
-        RuleKey.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer_policy::RuleKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return RuleKey.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          RuleKey.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer_policy::RuleKey<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: RuleKey.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => RuleKey.fromFields(T, fields),

--- a/ts/tests/gen/sui/transfer/structs.ts
+++ b/ts/tests/gen/sui/transfer/structs.ts
@@ -96,12 +96,18 @@ export class Receiving<T extends PhantomTypeArgument> implements StructClass {
   ): ReceivingReified<ToPhantomTypeArgument<T>> {
     const reifiedBcs = Receiving.bcs
     return {
-      typeName: Receiving.$typeName,
-      fullTypeName: composeSuiType(
-        Receiving.$typeName,
-        ...[extractType(T)],
-      ) as `0x2::transfer::Receiving<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`,
-      typeArgs: [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>],
+      get typeName() {
+        return Receiving.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Receiving.$typeName,
+          ...[extractType(T)],
+        ) as `0x2::transfer::Receiving<${PhantomToTypeStr<ToPhantomTypeArgument<T>>}>`
+      },
+      get typeArgs() {
+        return [extractType(T)] as [PhantomToTypeStr<ToPhantomTypeArgument<T>>]
+      },
       isPhantom: Receiving.$isPhantom,
       reifiedTypeArgs: [T],
       fromFields: (fields: Record<string, any>) => Receiving.fromFields(T, fields),

--- a/ts/tests/gen/sui/tx-context/structs.ts
+++ b/ts/tests/gen/sui/tx-context/structs.ts
@@ -110,11 +110,15 @@ export class TxContext implements StructClass {
   static reified(): TxContextReified {
     const reifiedBcs = TxContext.bcs
     return {
-      typeName: TxContext.$typeName,
-      fullTypeName: composeSuiType(
-        TxContext.$typeName,
-        ...[],
-      ) as `0x2::tx_context::TxContext`,
+      get typeName() {
+        return TxContext.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          TxContext.$typeName,
+          ...[],
+        ) as `0x2::tx_context::TxContext`
+      },
       typeArgs: [] as [],
       isPhantom: TxContext.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/url/structs.ts
+++ b/ts/tests/gen/sui/url/structs.ts
@@ -74,11 +74,15 @@ export class Url implements StructClass {
   static reified(): UrlReified {
     const reifiedBcs = Url.bcs
     return {
-      typeName: Url.$typeName,
-      fullTypeName: composeSuiType(
-        Url.$typeName,
-        ...[],
-      ) as `0x2::url::Url`,
+      get typeName() {
+        return Url.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Url.$typeName,
+          ...[],
+        ) as `0x2::url::Url`
+      },
       typeArgs: [] as [],
       isPhantom: Url.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/vec-map/structs.ts
+++ b/ts/tests/gen/sui/vec-map/structs.ts
@@ -94,15 +94,23 @@ export class VecMap<K extends TypeArgument, V extends TypeArgument> implements S
   ): VecMapReified<ToTypeArgument<K>, ToTypeArgument<V>> {
     const reifiedBcs = VecMap.bcs(toBcs(K), toBcs(V))
     return {
-      typeName: VecMap.$typeName,
-      fullTypeName: composeSuiType(
-        VecMap.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::vec_map::VecMap<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<ToTypeArgument<V>>}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<K>>,
-        ToTypeStr<ToTypeArgument<V>>,
-      ],
+      get typeName() {
+        return VecMap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VecMap.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::vec_map::VecMap<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<
+          ToTypeArgument<V>
+        >}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<K>>,
+          ToTypeStr<ToTypeArgument<V>>,
+        ]
+      },
       isPhantom: VecMap.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => VecMap.fromFields([K, V], fields),
@@ -378,15 +386,21 @@ export class Entry<K extends TypeArgument, V extends TypeArgument> implements St
   ): EntryReified<ToTypeArgument<K>, ToTypeArgument<V>> {
     const reifiedBcs = Entry.bcs(toBcs(K), toBcs(V))
     return {
-      typeName: Entry.$typeName,
-      fullTypeName: composeSuiType(
-        Entry.$typeName,
-        ...[extractType(K), extractType(V)],
-      ) as `0x2::vec_map::Entry<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<ToTypeArgument<V>>}>`,
-      typeArgs: [extractType(K), extractType(V)] as [
-        ToTypeStr<ToTypeArgument<K>>,
-        ToTypeStr<ToTypeArgument<V>>,
-      ],
+      get typeName() {
+        return Entry.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Entry.$typeName,
+          ...[extractType(K), extractType(V)],
+        ) as `0x2::vec_map::Entry<${ToTypeStr<ToTypeArgument<K>>}, ${ToTypeStr<ToTypeArgument<V>>}>`
+      },
+      get typeArgs() {
+        return [extractType(K), extractType(V)] as [
+          ToTypeStr<ToTypeArgument<K>>,
+          ToTypeStr<ToTypeArgument<V>>,
+        ]
+      },
       isPhantom: Entry.$isPhantom,
       reifiedTypeArgs: [K, V],
       fromFields: (fields: Record<string, any>) => Entry.fromFields([K, V], fields),

--- a/ts/tests/gen/sui/vec-set/structs.ts
+++ b/ts/tests/gen/sui/vec-set/structs.ts
@@ -89,12 +89,18 @@ export class VecSet<K extends TypeArgument> implements StructClass {
   ): VecSetReified<ToTypeArgument<K>> {
     const reifiedBcs = VecSet.bcs(toBcs(K))
     return {
-      typeName: VecSet.$typeName,
-      fullTypeName: composeSuiType(
-        VecSet.$typeName,
-        ...[extractType(K)],
-      ) as `0x2::vec_set::VecSet<${ToTypeStr<ToTypeArgument<K>>}>`,
-      typeArgs: [extractType(K)] as [ToTypeStr<ToTypeArgument<K>>],
+      get typeName() {
+        return VecSet.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VecSet.$typeName,
+          ...[extractType(K)],
+        ) as `0x2::vec_set::VecSet<${ToTypeStr<ToTypeArgument<K>>}>`
+      },
+      get typeArgs() {
+        return [extractType(K)] as [ToTypeStr<ToTypeArgument<K>>]
+      },
       isPhantom: VecSet.$isPhantom,
       reifiedTypeArgs: [K],
       fromFields: (fields: Record<string, any>) => VecSet.fromFields(K, fields),

--- a/ts/tests/gen/sui/versioned/structs.ts
+++ b/ts/tests/gen/sui/versioned/structs.ts
@@ -83,11 +83,15 @@ export class Versioned implements StructClass {
   static reified(): VersionedReified {
     const reifiedBcs = Versioned.bcs
     return {
-      typeName: Versioned.$typeName,
-      fullTypeName: composeSuiType(
-        Versioned.$typeName,
-        ...[],
-      ) as `0x2::versioned::Versioned`,
+      get typeName() {
+        return Versioned.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          Versioned.$typeName,
+          ...[],
+        ) as `0x2::versioned::Versioned`
+      },
       typeArgs: [] as [],
       isPhantom: Versioned.$isPhantom,
       reifiedTypeArgs: [],
@@ -279,11 +283,15 @@ export class VersionChangeCap implements StructClass {
   static reified(): VersionChangeCapReified {
     const reifiedBcs = VersionChangeCap.bcs
     return {
-      typeName: VersionChangeCap.$typeName,
-      fullTypeName: composeSuiType(
-        VersionChangeCap.$typeName,
-        ...[],
-      ) as `0x2::versioned::VersionChangeCap`,
+      get typeName() {
+        return VersionChangeCap.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VersionChangeCap.$typeName,
+          ...[],
+        ) as `0x2::versioned::VersionChangeCap`
+      },
       typeArgs: [] as [],
       isPhantom: VersionChangeCap.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/zklogin-verified-id/structs.ts
+++ b/ts/tests/gen/sui/zklogin-verified-id/structs.ts
@@ -106,11 +106,15 @@ export class VerifiedID implements StructClass {
   static reified(): VerifiedIDReified {
     const reifiedBcs = VerifiedID.bcs
     return {
-      typeName: VerifiedID.$typeName,
-      fullTypeName: composeSuiType(
-        VerifiedID.$typeName,
-        ...[],
-      ) as `0x2::zklogin_verified_id::VerifiedID`,
+      get typeName() {
+        return VerifiedID.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VerifiedID.$typeName,
+          ...[],
+        ) as `0x2::zklogin_verified_id::VerifiedID`
+      },
       typeArgs: [] as [],
       isPhantom: VerifiedID.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/gen/sui/zklogin-verified-issuer/structs.ts
+++ b/ts/tests/gen/sui/zklogin-verified-issuer/structs.ts
@@ -91,11 +91,15 @@ export class VerifiedIssuer implements StructClass {
   static reified(): VerifiedIssuerReified {
     const reifiedBcs = VerifiedIssuer.bcs
     return {
-      typeName: VerifiedIssuer.$typeName,
-      fullTypeName: composeSuiType(
-        VerifiedIssuer.$typeName,
-        ...[],
-      ) as `0x2::zklogin_verified_issuer::VerifiedIssuer`,
+      get typeName() {
+        return VerifiedIssuer.$typeName
+      },
+      get fullTypeName() {
+        return composeSuiType(
+          VerifiedIssuer.$typeName,
+          ...[],
+        ) as `0x2::zklogin_verified_issuer::VerifiedIssuer`
+      },
       typeArgs: [] as [],
       isPhantom: VerifiedIssuer.$isPhantom,
       reifiedTypeArgs: [],

--- a/ts/tests/type-name-env-switching.test.ts
+++ b/ts/tests/type-name-env-switching.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import {
+  cloneEnv,
+  getEnv,
+  getTypeOrigin,
+  setActiveEnv,
+  setActiveEnvWithConfig,
+  type EnvConfig,
+} from './gen/_envs'
+import { extractType, phantom } from './gen/_framework/reified'
+import { Dummy, WithGenericField } from './gen/examples/fixture/structs'
+import { SUI } from './gen/sui/sui/structs'
+import { Balance } from './gen/sui/balance/structs'
+
+// Reset to default env after these tests so other suites aren't affected.
+afterAll(() => {
+  setActiveEnv('testnet')
+})
+
+beforeEach(() => {
+  setActiveEnv('testnet')
+})
+
+/**
+ * Build a synthetic env in which the `examples` package has been "republished"
+ * to `swappedAddr`. Every `examples` typeOrigin is rewritten to that address,
+ * which is enough to exercise dynamic-typeName behavior end-to-end.
+ */
+function envWithExamplesAt(swappedAddr: string): EnvConfig {
+  const base = getEnv('testnet')
+  const newOrigins: Record<string, string> = {}
+  for (const key of Object.keys(base.packages.examples.typeOrigins)) {
+    newOrigins[key] = swappedAddr
+  }
+  return cloneEnv(base, {
+    packages: {
+      examples: {
+        originalId: swappedAddr,
+        publishedAt: swappedAddr,
+        typeOrigins: newOrigins,
+      },
+    },
+  })
+}
+
+const SWAPPED = '0xc0ffee00000000000000000000000000000000000000000000000000c0ffeeee'
+
+describe('Dynamic-package $typeName follows the active env', () => {
+  it('Dummy.$typeName resolves against the active env on every read', () => {
+    setActiveEnv('testnet')
+    const initial = Dummy.$typeName
+    expect(initial).toBe(`${getTypeOrigin('examples', 'fixture::Dummy')}::fixture::Dummy`)
+
+    setActiveEnvWithConfig(envWithExamplesAt(SWAPPED))
+    expect(Dummy.$typeName).toBe(`${SWAPPED}::fixture::Dummy`)
+    expect(Dummy.$typeName).not.toBe(initial)
+  })
+
+  it('the read site does not cache — switching back resets the value', () => {
+    setActiveEnv('testnet')
+    const initial = Dummy.$typeName
+
+    setActiveEnvWithConfig(envWithExamplesAt(SWAPPED))
+    expect(Dummy.$typeName).toBe(`${SWAPPED}::fixture::Dummy`)
+
+    setActiveEnv('testnet')
+    expect(Dummy.$typeName).toBe(initial)
+  })
+})
+
+describe('System-package $typeName is constant across env switches', () => {
+  it('Balance.$typeName stays 0x2::balance::Balance regardless of env', () => {
+    setActiveEnv('testnet')
+    expect(Balance.$typeName).toBe('0x2::balance::Balance')
+
+    setActiveEnvWithConfig(envWithExamplesAt(SWAPPED))
+    expect(Balance.$typeName).toBe('0x2::balance::Balance')
+  })
+})
+
+describe('Stored reified handles follow env switches', () => {
+  it('typeName / fullTypeName / typeArgs on a stored handle update after the active env changes', () => {
+    setActiveEnv('testnet')
+    // Capture a reified handle under testnet — the exact pattern kai-ts-sdk uses
+    // when storing `this.r = SupplyPool_.r(args.T.r, args.ST.r)` in a constructor.
+    // (T in WithGenericField is non-phantom, so we pass `SUI.r` here.)
+    const stored = WithGenericField.reified(SUI.r)
+
+    const testnetAddr = getTypeOrigin('examples', 'fixture::WithGenericField')
+    expect(stored.typeName).toBe(`${testnetAddr}::fixture::WithGenericField`)
+    expect(stored.fullTypeName).toBe(`${testnetAddr}::fixture::WithGenericField<0x2::sui::SUI>`)
+    expect(stored.typeArgs).toEqual(['0x2::sui::SUI'])
+
+    setActiveEnvWithConfig(envWithExamplesAt(SWAPPED))
+
+    // Same handle, now reading through the new env. This is what was previously
+    // broken: stored handles leaked the auto-init env's address into PTBs.
+    expect(stored.typeName).toBe(`${SWAPPED}::fixture::WithGenericField`)
+    expect(stored.fullTypeName).toBe(`${SWAPPED}::fixture::WithGenericField<0x2::sui::SUI>`)
+    // typeArgs unchanged here because SUI is a System type (constant 0x2).
+    expect(stored.typeArgs).toEqual(['0x2::sui::SUI'])
+  })
+
+  it('typeArgs reflects env when the type arg is itself a Dynamic struct', () => {
+    setActiveEnv('testnet')
+    // Nest a Dynamic reified inside another Dynamic struct's reified handle.
+    const stored = WithGenericField.reified(Dummy.r)
+
+    expect(stored.typeArgs[0]).toBe(
+      `${getTypeOrigin('examples', 'fixture::Dummy')}::fixture::Dummy`
+    )
+
+    setActiveEnvWithConfig(envWithExamplesAt(SWAPPED))
+    // The inner reified's fullTypeName is recomputed too — getter-all-the-way-down
+    // through extractType -> reified.fullTypeName -> Name.$typeName getter.
+    expect(stored.typeArgs[0]).toBe(`${SWAPPED}::fixture::Dummy`)
+  })
+})
+
+describe('phantom() handles follow env switches', () => {
+  it('phantomType on a phantom(reified) is re-read each access', () => {
+    setActiveEnv('testnet')
+    const ph = phantom(Dummy.reified())
+
+    const testnetAddr = getTypeOrigin('examples', 'fixture::Dummy')
+    expect(ph.phantomType).toBe(`${testnetAddr}::fixture::Dummy`)
+    // extractType reads `.fullTypeName` / `.phantomType` — exercise both.
+    expect(extractType(ph)).toBe(`${testnetAddr}::fixture::Dummy`)
+
+    setActiveEnvWithConfig(envWithExamplesAt(SWAPPED))
+    expect(ph.phantomType).toBe(`${SWAPPED}::fixture::Dummy`)
+    expect(extractType(ph)).toBe(`${SWAPPED}::fixture::Dummy`)
+  })
+
+  it('phantom(stringLiteral) is a snapshot (the string was already finalized)', () => {
+    // The string branch of phantom() doesn't have a reified to read through, so
+    // it stays a plain field. This pins that behavior.
+    const ph = phantom('0xdead::module::Type')
+    expect(ph.phantomType).toBe('0xdead::module::Type')
+
+    setActiveEnvWithConfig(envWithExamplesAt(SWAPPED))
+    expect(ph.phantomType).toBe('0xdead::module::Type')
+  })
+})

--- a/ts/tests/type-name-env-switching.test.ts
+++ b/ts/tests/type-name-env-switching.test.ts
@@ -81,7 +81,7 @@ describe('System-package $typeName is constant across env switches', () => {
 describe('Stored reified handles follow env switches', () => {
   it('typeName / fullTypeName / typeArgs on a stored handle update after the active env changes', () => {
     setActiveEnv('testnet')
-    // Capture a reified handle under testnet — the exact pattern kai-ts-sdk uses
+    // Capture a reified handle under testnet — the pattern wrapper SDKs use
     // when storing `this.r = SupplyPool_.r(args.T.r, args.ST.r)` in a constructor.
     // (T in WithGenericField is non-phantom, so we pass `SUI.r` here.)
     const stored = WithGenericField.reified(SUI.r)


### PR DESCRIPTION
## Summary

`$typeName` was emitted as a `static readonly` initialized at class-load time, which captured whichever env was active during the `_envs/index.ts` auto-init (typically `mainnet`). Later `setActiveEnv()` calls didn't update the frozen value, so any function wrapper interpolating `${Foo.$typeName}` into a PTB argument (most commonly `vector<T>` args) leaked the auto-init env's address into transactions built under a different env.

This stack makes `$typeName` resolve against the active env on every read, and extends the same fix through reified-handle and phantom-handle paths so SDKs that store reified handles long-term (`this.r = Foo.r(...)`, module-level constants) follow env switches too.

## What changed

- **Struct/enum `\$typeName`** becomes a `static get` for Dynamic packages. System packages (std at `0x1`, sui at `0x2`) keep `static readonly` so their literal-type narrowing survives.
- **Enum variant `\$typeName`** delegates to the parent enum's getter, rather than capturing the parent's value at variant-class-load time.
- **`static reified()` return-object** identity fields (`typeName`, `fullTypeName`, `typeArgs`) are object-literal getters so stored handles read live.
- **`framework/reified.ts` `phantom(reifiedHandle)`** returns a getter for `phantomType` so `extractType(phantom(...))` reflects the active env.

See [ADR-005](docs/adr/005-dynamic-typename-via-getters.md) for the full design rationale (getter vs method, system-package preservation, recursion through reified/phantom) and how this composes with the eventual per-instance facade rework.

## Test plan

- [x] \`cargo test\` — 169 tests pass (84 unit, 23 model_builder, 5 multi_env, 56 snapshot, 1 doctest).
- [x] New System-package fixtures + invariant assertions pin the Dynamic-vs-System conditional in the emission templates.
- [x] \`pnpm run check\` — TypeScript build clean.
- [x] \`pnpm test\` — 99 vitest tests pass, including 7 new end-to-end cases in \`ts/tests/type-name-env-switching.test.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)